### PR TITLE
Fix: #17 - See the pull request from https://github.com/googleapis/google-cloud-node/pull/9218? Instead of doing this for paginator, do the same thing as this pull request for the spanner-driver library to migrate to Jest.

### DIFF
--- a/handwritten/spanner-driver/.c8rc.json
+++ b/handwritten/spanner-driver/.c8rc.json
@@ -1,5 +1,0 @@
-{
-  "include": ["src/**/*.ts"],
-  "reporter": ["text", "lcov"],
-  "all": true
-}

--- a/handwritten/spanner-driver/.eslintrc.json
+++ b/handwritten/spanner-driver/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../node_modules/gts",
+  "extends": "./node_modules/gts",
   "root": true,
   "rules": {
     "@typescript-eslint/no-floating-promises": "off"

--- a/handwritten/spanner-driver/jest.config.js
+++ b/handwritten/spanner-driver/jest.config.js
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const config = {
-  "enable-source-maps": true,
-  "throw-deprecation": true,
-  "timeout": 10000,
-  "recursive": true
-}
-if (process.env.MOCHA_THROW_DEPRECATION === 'false') {
-  delete config['throw-deprecation'];
-}
-if (process.env.MOCHA_REPORTER) {
-  config.reporter = process.env.MOCHA_REPORTER;
-}
-if (process.env.MOCHA_REPORTER_OUTPUT) {
-  config['reporter-option'] = `output=${process.env.MOCHA_REPORTER_OUTPUT}`;
-}
-module.exports = config
+export default {
+  testMatch: ['<rootDir>/test/**/*_test.ts', '<rootDir>/system-test/**/*.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json',
+        diagnostics: {
+          ignoreCodes: [151002],
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  clearMocks: true,
+};

--- a/handwritten/spanner-driver/package.json
+++ b/handwritten/spanner-driver/package.json
@@ -39,10 +39,8 @@
     "lint": "gts check",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "test:esm": "c8 mocha build/esm/test/unit/**/*.js",
-    "test:cjs": "c8 mocha build/cjs/test/unit/**/*.js",
-    "test": "npm run test:esm && npm run test:cjs",
-    "system-test": "mocha build/esm/system-test/**/*.js --timeout 60000",
+    "test": "jest test/unit --coverage",
+    "system-test": "jest system-test",
     "test:pg-suite": "node test/pg-suite/run_pg_suite.cjs"
   },
   "dependencies": {
@@ -50,13 +48,11 @@
   },
   "devDependencies": {
     "@google-cloud/spanner": "^8.7.1",
-    "@types/mocha": "^10.0.10",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.13.9",
-    "@types/sinon": "^17.0.4",
-    "c8": "^10.1.3",
     "gts": "^6.0.2",
-    "mocha": "^11.1.0",
-    "sinon": "^21.0.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.12",
     "typescript": "^5.8.2"
   },
   "engines": {
@@ -64,8 +60,8 @@
   },
   "optionalDependencies": {
     "@google-cloud/spannerlib-node-darwin-arm64": "^0.2.0",
-    "@google-cloud/spannerlib-node-linux-x64": "^0.2.0",
     "@google-cloud/spannerlib-node-linux-arm64": "^0.2.0",
+    "@google-cloud/spannerlib-node-linux-x64": "^0.2.0",
     "@google-cloud/spannerlib-node-win32-x64": "^0.2.0"
   }
 }

--- a/handwritten/spanner-driver/src/lib/codec.ts
+++ b/handwritten/spanner-driver/src/lib/codec.ts
@@ -23,10 +23,13 @@ import {
 } from './types.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import pkg from '@google-cloud/spanner-api/build/protos/protos.js';
+import * as pkg from '@google-cloud/spanner-api/build/protos/protos.js';
 import type {google as GoogleProto} from '@google-cloud/spanner-api/build/protos/protos.js';
 
-const {google} = pkg as {google: typeof GoogleProto};
+const google =
+  (pkg as unknown as {google: typeof GoogleProto}).google ||
+  (pkg as unknown as {default: {google: typeof GoogleProto}}).default?.google ||
+  (pkg as unknown as {default: typeof GoogleProto}).default;
 const TypeCode = google.spanner.v1.TypeCode;
 
 export interface EncodedParam {

--- a/handwritten/spanner-driver/src/lib/pg/types.ts
+++ b/handwritten/spanner-driver/src/lib/pg/types.ts
@@ -15,10 +15,13 @@
 import type {ITypeOverrides, TypeParser} from '../types.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import pkg from '@google-cloud/spanner-api/build/protos/protos.js';
+import * as pkg from '@google-cloud/spanner-api/build/protos/protos.js';
 import type {google as GoogleProto} from '@google-cloud/spanner-api/build/protos/protos.js';
 
-const {google} = pkg as {google: typeof GoogleProto};
+const google =
+  (pkg as unknown as {google: typeof GoogleProto}).google ||
+  (pkg as unknown as {default: {google: typeof GoogleProto}}).default?.google ||
+  (pkg as unknown as {default: typeof GoogleProto}).default;
 const TypeCode = google.spanner.v1.TypeCode;
 const TypeAnnotationCode = google.spanner.v1.TypeAnnotationCode;
 

--- a/handwritten/spanner-driver/system-test/driver.ts
+++ b/handwritten/spanner-driver/system-test/driver.ts
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {after, before, describe, it} from 'mocha';
 import {Spanner, protos} from '@google-cloud/spanner';
 import {BuiltinOids, Client, Pool, QueryResult} from '../src/index.js';
 
-describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
-  this.timeout(180000); // 3 minutes to allow Spanner DDL / Database creation
+describe('Spanner Driver System Tests (PostgreSQL Dialect)', () => {
+  jest.setTimeout(180000); // 3 minutes to allow Spanner DDL / Database creation
 
   const rawConn =
     process.env.SPANNER_CONNECTION_STRING ||
@@ -77,7 +75,7 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
   let client: Client;
   let pool: Pool;
 
-  before(async () => {
+  beforeAll(async () => {
     if (shouldCreateDb) {
       console.log(
         `Creating temporary Spanner PostgreSQL database: ${dbName}...`,
@@ -453,7 +451,7 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
     }
   });
 
-  after(async () => {
+  afterAll(async () => {
     try {
       if (client && client.isConnected) {
         await client.end();
@@ -497,25 +495,24 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query(
           'SELECT SingerId, FirstName, LastName, BirthDate, LastModified, Rating, Active, Revenues, Metadata FROM Singers WHERE SingerId = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.ok(row, 'Expected row to be returned');
-        assert.strictEqual(String(row.singerid || row.SingerId), '1');
-        assert.strictEqual(row.firstname || row.FirstName, 'Marc');
-        assert.strictEqual(row.lastname || row.LastName, 'Richards');
-        assert.strictEqual(row.birthdate || row.BirthDate, '1980-01-05');
-        assert.ok(
+        expect(row).toBeTruthy();
+        expect(String(row.singerid || row.SingerId)).toBe('1');
+        expect(row.firstname || row.FirstName).toBe('Marc');
+        expect(row.lastname || row.LastName).toBe('Richards');
+        expect(row.birthdate || row.BirthDate).toBe('1980-01-05');
+        expect(
           (row.lastmodified || row.LastModified) instanceof Date,
-          'Expected LastModified to be Date instance',
-        );
-        assert.strictEqual(row.active ?? row.Active, true);
-        assert.strictEqual(Number(row.rating || row.Rating), 4.8);
-        assert.strictEqual(Number(row.revenues || row.Revenues), 125000.5);
+        ).toBeTruthy();
+        expect(row.active ?? row.Active).toBe(true);
+        expect(Number(row.rating || row.Rating)).toBe(4.8);
+        expect(Number(row.revenues || row.Revenues)).toBe(125000.5);
 
         const meta = (row.metadata || row.Metadata) as
           | {genre?: string}
           | undefined;
-        assert.strictEqual(meta?.genre, 'rock');
+        expect(meta?.genre).toBe('rock');
       });
 
       it('should execute parameterized query with numeric parameter ($1)', async () => {
@@ -523,11 +520,11 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName, Active FROM Singers WHERE SingerId = $1',
           [2],
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.strictEqual(String(row.singerid || row.SingerId), '2');
-        assert.strictEqual(row.firstname || row.FirstName, 'Catalina');
-        assert.strictEqual(row.active ?? row.Active, false);
+        expect(String(row.singerid || row.SingerId)).toBe('2');
+        expect(row.firstname || row.FirstName).toBe('Catalina');
+        expect(row.active ?? row.Active).toBe(false);
       });
 
       it('should execute parameterized query with string parameter ($1)', async () => {
@@ -535,9 +532,9 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName, LastName FROM Singers WHERE LastName = $1',
           ['Richards'],
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.strictEqual(row.firstname || row.FirstName, 'Marc');
+        expect(row.firstname || row.FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query with date parameter ($1::date)', async () => {
@@ -545,11 +542,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE BirthDate = $1::date',
           ['1980-01-05'],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query with timestamptz Date parameter ($1)', async () => {
@@ -557,11 +551,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE LastModified = $1',
           [new Date('2023-01-01T12:00:00.000Z')],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query with boolean parameter ($1)', async () => {
@@ -569,11 +560,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE Active = $1',
           [true],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query with numeric/decimal parameter ($1::numeric)', async () => {
@@ -581,11 +569,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE Revenues = $1::numeric',
           ['125000.50'],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query filtering jsonb column (Metadata ->> $1)', async () => {
@@ -593,19 +578,16 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           "SELECT SingerId, FirstName FROM Singers WHERE Metadata ->> 'genre' = $1",
           ['rock'],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should encode and decode jsonb parameter ($1::jsonb)', async () => {
         const res = await client.query('SELECT $1::jsonb as payload', [
           {genre: 'rock', tracks: 12},
         ]);
-        assert.strictEqual(res.rowCount, 1);
-        assert.deepStrictEqual(res.rows[0].payload, {
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].payload).toEqual({
           genre: 'rock',
           tracks: 12,
         });
@@ -616,54 +598,45 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query('SELECT $1::bytea as bin_data', [
           payload,
         ]);
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const returnedBuf = res.rows[0].bin_data as Buffer;
-        assert.ok(Buffer.isBuffer(returnedBuf));
-        assert.deepStrictEqual(returnedBuf, payload);
+        expect(Buffer.isBuffer(returnedBuf)).toBeTruthy();
+        expect(returnedBuf).toEqual(payload);
       });
 
       it('should read and decode all table-storable scalar column types from AllTypes table', async () => {
         const res = await client.query(
           'SELECT ColBool, ColBytea, ColInt8, ColFloat4, ColFloat8, ColNumeric, ColText, ColVarchar, ColDate, ColTimestamp, ColJsonb, ColUuid FROM AllTypes WHERE Id = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.ok(row, 'Expected row to be returned');
-        assert.strictEqual(row.colbool ?? row.ColBool, true);
+        expect(row).toBeTruthy();
+        expect(row.colbool ?? row.ColBool).toBe(true);
         const bytea = (row.colbytea || row.ColBytea) as Buffer;
-        assert.ok(Buffer.isBuffer(bytea));
-        assert.strictEqual(bytea.toString(), 'Spanner Binary Data');
-        assert.strictEqual(
-          String(row.colint8 || row.ColInt8),
-          '9223372036854775807',
-        );
-        assert.ok(
+        expect(Buffer.isBuffer(bytea)).toBeTruthy();
+        expect(bytea.toString()).toBe('Spanner Binary Data');
+        expect(String(row.colint8 || row.ColInt8)).toBe('9223372036854775807');
+        expect(
           Math.abs(Number(row.colfloat4 || row.ColFloat4) - 3.14) < 0.001,
-        );
-        assert.ok(
+        ).toBeTruthy();
+        expect(
           Math.abs(Number(row.colfloat8 || row.ColFloat8) - 2.718281828459045) <
             0.000001,
-        );
-        assert.strictEqual(
-          String(row.colnumeric || row.ColNumeric),
+        ).toBeTruthy();
+        expect(String(row.colnumeric || row.ColNumeric)).toBe(
           '123456789.987654321',
         );
-        assert.strictEqual(
-          row.coltext || row.ColText,
-          'Hello Spanner PostgreSQL',
-        );
-        assert.strictEqual(row.colvarchar || row.ColVarchar, 'Varchar sample');
-        assert.strictEqual(row.coldate || row.ColDate, '2026-08-14');
-        assert.ok(
+        expect(row.coltext || row.ColText).toBe('Hello Spanner PostgreSQL');
+        expect(row.colvarchar || row.ColVarchar).toBe('Varchar sample');
+        expect(row.coldate || row.ColDate).toBe('2026-08-14');
+        expect(
           (row.coltimestamp || row.ColTimestamp) instanceof Date,
-          'Expected ColTimestamp to be Date instance',
-        );
-        assert.deepStrictEqual(row.coljsonb || row.ColJsonb, {
+        ).toBeTruthy();
+        expect(row.coljsonb || row.ColJsonb).toEqual({
           name: 'Spanner',
           dialect: 'postgresql',
         });
-        assert.strictEqual(
-          row.coluuid || row.ColUuid,
+        expect(row.coluuid || row.ColUuid).toBe(
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
         );
       });
@@ -673,36 +646,38 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query('SELECT $1::uuid as uuid_val', [
           uuidVal,
         ]);
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(res.rows[0].uuid_val, uuidVal);
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].uuid_val).toBe(uuidVal);
       });
 
       it('should execute query with interval expression and date arithmetic', async () => {
         const res = await client.query(
           "SELECT CAST('1 year 2 months 3 days' AS INTERVAL) as interval_val, ('2026-01-01 00:00:00+00'::timestamptz + CAST('1 year 2 months 3 days' AS INTERVAL)) as shifted_time",
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.ok(
+        expect(res.rowCount).toBe(1);
+        expect(
           typeof res.rows[0].interval_val === 'string' &&
             res.rows[0].interval_val.length > 0,
-        );
-        assert.ok(res.rows[0].shifted_time instanceof Date);
+        ).toBeTruthy();
+        expect(res.rows[0].shifted_time instanceof Date).toBeTruthy();
       });
 
       it('should execute parameterized query with float4 parameter ($1::float4)', async () => {
         const res = await client.query('SELECT $1::float4 as f4_val', [3.14]);
-        assert.strictEqual(res.rowCount, 1);
-        assert.ok(Math.abs(Number(res.rows[0].f4_val) - 3.14) < 0.001);
+        expect(res.rowCount).toBe(1);
+        expect(
+          Math.abs(Number(res.rows[0].f4_val) - 3.14) < 0.001,
+        ).toBeTruthy();
       });
 
       it('should execute parameterized query with float8 parameter ($1::float8)', async () => {
         const res = await client.query('SELECT $1::float8 as f8_val', [
           2.718281828459045,
         ]);
-        assert.strictEqual(res.rowCount, 1);
-        assert.ok(
+        expect(res.rowCount).toBe(1);
+        expect(
           Math.abs(Number(res.rows[0].f8_val) - 2.718281828459045) < 0.000001,
-        );
+        ).toBeTruthy();
       });
     });
 
@@ -711,8 +686,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query(
           'SELECT SingerId, Tags FROM Singers WHERE SingerId = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.deepStrictEqual(res.rows[0].tags || res.rows[0].Tags, [
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].tags || res.rows[0].Tags).toEqual([
           'rock',
           'classic',
         ]);
@@ -722,46 +697,35 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query(
           'SELECT ArrBool, ArrBytea, ArrInt8, ArrFloat4, ArrFloat8, ArrNumeric, ArrText, ArrDate, ArrTimestamp, ArrJsonb, ArrUuid FROM AllTypes WHERE Id = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.deepStrictEqual(row.arrbool || row.ArrBool, [true, false, true]);
+        expect(row.arrbool || row.ArrBool).toEqual([true, false, true]);
         const byteaArr = (row.arrbytea || row.ArrBytea) as Buffer[];
-        assert.ok(Array.isArray(byteaArr));
-        assert.strictEqual(byteaArr[0].toString(), 'bin1');
-        assert.strictEqual(byteaArr[1].toString(), 'bin2');
-        assert.deepStrictEqual(row.arrint8 || row.ArrInt8, [
-          '100',
-          '200',
-          '300',
-        ]);
+        expect(Array.isArray(byteaArr)).toBeTruthy();
+        expect(byteaArr[0].toString()).toBe('bin1');
+        expect(byteaArr[1].toString()).toBe('bin2');
+        expect(row.arrint8 || row.ArrInt8).toEqual(['100', '200', '300']);
         const float4Arr = (row.arrfloat4 || row.ArrFloat4) as number[];
-        assert.ok(Math.abs(float4Arr[0] - 1.1) < 0.01);
-        assert.ok(Math.abs(float4Arr[1] - 2.2) < 0.01);
+        expect(Math.abs(float4Arr[0] - 1.1) < 0.01).toBeTruthy();
+        expect(Math.abs(float4Arr[1] - 2.2) < 0.01).toBeTruthy();
         const float8Arr = (row.arrfloat8 || row.ArrFloat8) as number[];
-        assert.ok(Math.abs(float8Arr[0] - 3.1415) < 0.0001);
-        assert.ok(Math.abs(float8Arr[1] - 2.7182) < 0.0001);
-        assert.deepStrictEqual(row.arrnumeric || row.ArrNumeric, [
+        expect(Math.abs(float8Arr[0] - 3.1415) < 0.0001).toBeTruthy();
+        expect(Math.abs(float8Arr[1] - 2.7182) < 0.0001).toBeTruthy();
+        expect(row.arrnumeric || row.ArrNumeric).toEqual([
           '10.5',
           '20.25',
           '30.125',
         ]);
-        assert.deepStrictEqual(row.arrtext || row.ArrText, [
-          'alpha',
-          'beta',
-          'gamma',
-        ]);
-        assert.deepStrictEqual(row.arrdate || row.ArrDate, [
+        expect(row.arrtext || row.ArrText).toEqual(['alpha', 'beta', 'gamma']);
+        expect(row.arrdate || row.ArrDate).toEqual([
           '2026-01-01',
           '2026-06-01',
         ]);
         const tsArr = (row.arrtimestamp || row.ArrTimestamp) as Date[];
-        assert.ok(tsArr[0] instanceof Date);
-        assert.ok(tsArr[1] instanceof Date);
-        assert.deepStrictEqual(row.arrjsonb || row.ArrJsonb, [
-          {k: 'v1'},
-          {k: 'v2'},
-        ]);
-        assert.deepStrictEqual(row.arruuid || row.ArrUuid, [
+        expect(tsArr[0] instanceof Date).toBeTruthy();
+        expect(tsArr[1] instanceof Date).toBeTruthy();
+        expect(row.arrjsonb || row.ArrJsonb).toEqual([{k: 'v1'}, {k: 'v2'}]);
+        expect(row.arruuid || row.ArrUuid).toEqual([
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           'b1ffcd00-0d1c-5fa9-cc7e-7cc0ce491b22',
         ]);
@@ -772,11 +736,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE $1 = ANY(Tags)',
           ['rock'],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should execute parameterized query with numeric array parameter ($1 = ANY)', async () => {
@@ -784,16 +745,10 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE SingerId = ANY($1) ORDER BY SingerId',
           [[1, 2]],
         );
-        assert.strictEqual(res.rowCount, 2);
-        assert.strictEqual(res.rows.length, 2);
-        assert.strictEqual(
-          String(res.rows[0].singerid || res.rows[0].SingerId),
-          '1',
-        );
-        assert.strictEqual(
-          String(res.rows[1].singerid || res.rows[1].SingerId),
-          '2',
-        );
+        expect(res.rowCount).toBe(2);
+        expect(res.rows.length).toBe(2);
+        expect(String(res.rows[0].singerid || res.rows[0].SingerId)).toBe('1');
+        expect(String(res.rows[1].singerid || res.rows[1].SingerId)).toBe('2');
       });
 
       it('should execute parameterized query with string array parameter ($1 = ANY)', async () => {
@@ -801,15 +756,9 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, LastName FROM Singers WHERE LastName = ANY($1) ORDER BY SingerId',
           [['Richards', 'Smith']],
         );
-        assert.strictEqual(res.rowCount, 2);
-        assert.strictEqual(
-          res.rows[0].lastname || res.rows[0].LastName,
-          'Richards',
-        );
-        assert.strictEqual(
-          res.rows[1].lastname || res.rows[1].LastName,
-          'Smith',
-        );
+        expect(res.rowCount).toBe(2);
+        expect(res.rows[0].lastname || res.rows[0].LastName).toBe('Richards');
+        expect(res.rows[1].lastname || res.rows[1].LastName).toBe('Smith');
       });
 
       it('should encode and decode array types ($1::text[] and $2::bigint[])', async () => {
@@ -820,117 +769,105 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
             [10, 20, 30],
           ],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.deepStrictEqual(res.rows[0].text_arr, [
-          'apple',
-          'banana',
-          'cherry',
-        ]);
-        assert.deepStrictEqual(res.rows[0].int_arr, ['10', '20', '30']);
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].text_arr).toEqual(['apple', 'banana', 'cherry']);
+        expect(res.rows[0].int_arr).toEqual(['10', '20', '30']);
       });
 
       it('should read and decode row with all NULL column values (Id = 2)', async () => {
         const res = await client.query(
           'SELECT ColBool, ColBytea, ColInt8, ColFloat4, ColFloat8, ColNumeric, ColText, ColVarchar, ColDate, ColTimestamp, ColJsonb, ColUuid, ArrBool, ArrBytea, ArrInt8, ArrFloat4, ArrFloat8, ArrNumeric, ArrText, ArrDate, ArrTimestamp, ArrJsonb, ArrUuid FROM AllTypes WHERE Id = 2',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0] as Record<string, unknown>;
-        assert.ok(row, 'Expected row to be returned');
+        expect(row).toBeTruthy();
         const getCol = (name: string) =>
           row[name.toLowerCase()] !== undefined
             ? row[name.toLowerCase()]
             : row[name];
 
-        assert.strictEqual(getCol('ColBool'), null);
-        assert.strictEqual(getCol('ColBytea'), null);
-        assert.strictEqual(getCol('ColInt8'), null);
-        assert.strictEqual(getCol('ColFloat4'), null);
-        assert.strictEqual(getCol('ColFloat8'), null);
-        assert.strictEqual(getCol('ColNumeric'), null);
-        assert.strictEqual(getCol('ColText'), null);
-        assert.strictEqual(getCol('ColVarchar'), null);
-        assert.strictEqual(getCol('ColDate'), null);
-        assert.strictEqual(getCol('ColTimestamp'), null);
-        assert.strictEqual(getCol('ColJsonb'), null);
-        assert.strictEqual(getCol('ColUuid'), null);
-        assert.strictEqual(getCol('ArrBool'), null);
-        assert.strictEqual(getCol('ArrBytea'), null);
-        assert.strictEqual(getCol('ArrInt8'), null);
-        assert.strictEqual(getCol('ArrFloat4'), null);
-        assert.strictEqual(getCol('ArrFloat8'), null);
-        assert.strictEqual(getCol('ArrNumeric'), null);
-        assert.strictEqual(getCol('ArrText'), null);
-        assert.strictEqual(getCol('ArrDate'), null);
-        assert.strictEqual(getCol('ArrTimestamp'), null);
-        assert.strictEqual(getCol('ArrJsonb'), null);
-        assert.strictEqual(getCol('ArrUuid'), null);
+        expect(getCol('ColBool')).toBe(null);
+        expect(getCol('ColBytea')).toBe(null);
+        expect(getCol('ColInt8')).toBe(null);
+        expect(getCol('ColFloat4')).toBe(null);
+        expect(getCol('ColFloat8')).toBe(null);
+        expect(getCol('ColNumeric')).toBe(null);
+        expect(getCol('ColText')).toBe(null);
+        expect(getCol('ColVarchar')).toBe(null);
+        expect(getCol('ColDate')).toBe(null);
+        expect(getCol('ColTimestamp')).toBe(null);
+        expect(getCol('ColJsonb')).toBe(null);
+        expect(getCol('ColUuid')).toBe(null);
+        expect(getCol('ArrBool')).toBe(null);
+        expect(getCol('ArrBytea')).toBe(null);
+        expect(getCol('ArrInt8')).toBe(null);
+        expect(getCol('ArrFloat4')).toBe(null);
+        expect(getCol('ArrFloat8')).toBe(null);
+        expect(getCol('ArrNumeric')).toBe(null);
+        expect(getCol('ArrText')).toBe(null);
+        expect(getCol('ArrDate')).toBe(null);
+        expect(getCol('ArrTimestamp')).toBe(null);
+        expect(getCol('ArrJsonb')).toBe(null);
+        expect(getCol('ArrUuid')).toBe(null);
       });
 
       it('should read and decode row with empty array columns (Id = 3)', async () => {
         const res = await client.query(
           'SELECT ArrBool, ArrBytea, ArrInt8, ArrFloat4, ArrFloat8, ArrNumeric, ArrText, ArrDate, ArrTimestamp, ArrJsonb, ArrUuid FROM AllTypes WHERE Id = 3',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.deepStrictEqual(row.arrbool || row.ArrBool, []);
-        assert.deepStrictEqual(row.arrbytea || row.ArrBytea, []);
-        assert.deepStrictEqual(row.arrint8 || row.ArrInt8, []);
-        assert.deepStrictEqual(row.arrfloat4 || row.ArrFloat4, []);
-        assert.deepStrictEqual(row.arrfloat8 || row.ArrFloat8, []);
-        assert.deepStrictEqual(row.arrnumeric || row.ArrNumeric, []);
-        assert.deepStrictEqual(row.arrtext || row.ArrText, []);
-        assert.deepStrictEqual(row.arrdate || row.ArrDate, []);
-        assert.deepStrictEqual(row.arrtimestamp || row.ArrTimestamp, []);
-        assert.deepStrictEqual(row.arrjsonb || row.ArrJsonb, []);
-        assert.deepStrictEqual(row.arruuid || row.ArrUuid, []);
+        expect(row.arrbool || row.ArrBool).toEqual([]);
+        expect(row.arrbytea || row.ArrBytea).toEqual([]);
+        expect(row.arrint8 || row.ArrInt8).toEqual([]);
+        expect(row.arrfloat4 || row.ArrFloat4).toEqual([]);
+        expect(row.arrfloat8 || row.ArrFloat8).toEqual([]);
+        expect(row.arrnumeric || row.ArrNumeric).toEqual([]);
+        expect(row.arrtext || row.ArrText).toEqual([]);
+        expect(row.arrdate || row.ArrDate).toEqual([]);
+        expect(row.arrtimestamp || row.ArrTimestamp).toEqual([]);
+        expect(row.arrjsonb || row.ArrJsonb).toEqual([]);
+        expect(row.arruuid || row.ArrUuid).toEqual([]);
       });
 
       it('should read and decode row with arrays containing NULL elements (Id = 4)', async () => {
         const res = await client.query(
           'SELECT ArrBool, ArrBytea, ArrInt8, ArrFloat4, ArrFloat8, ArrNumeric, ArrText, ArrDate, ArrTimestamp, ArrJsonb, ArrUuid FROM AllTypes WHERE Id = 4',
         );
-        assert.strictEqual(res.rowCount, 1);
+        expect(res.rowCount).toBe(1);
         const row = res.rows[0];
-        assert.deepStrictEqual(row.arrbool || row.ArrBool, [true, null, false]);
+        expect(row.arrbool || row.ArrBool).toEqual([true, null, false]);
         const byteaArr = (row.arrbytea || row.ArrBytea) as (Buffer | null)[];
-        assert.ok(Array.isArray(byteaArr));
-        assert.strictEqual(byteaArr[0]?.toString(), 'bin1');
-        assert.strictEqual(byteaArr[1], null);
-        assert.strictEqual(byteaArr[2]?.toString(), 'bin3');
-        assert.deepStrictEqual(row.arrint8 || row.ArrInt8, [
-          '100',
-          null,
-          '300',
-        ]);
+        expect(Array.isArray(byteaArr)).toBeTruthy();
+        expect(byteaArr[0]?.toString()).toBe('bin1');
+        expect(byteaArr[1]).toBe(null);
+        expect(byteaArr[2]?.toString()).toBe('bin3');
+        expect(row.arrint8 || row.ArrInt8).toEqual(['100', null, '300']);
         const float4Arr = (row.arrfloat4 || row.ArrFloat4) as (number | null)[];
-        assert.ok(Math.abs(float4Arr[0]! - 1.1) < 0.01);
-        assert.strictEqual(float4Arr[1], null);
-        assert.ok(Math.abs(float4Arr[2]! - 3.3) < 0.01);
-        assert.deepStrictEqual(row.arrnumeric || row.ArrNumeric, [
+        expect(Math.abs(float4Arr[0]! - 1.1) < 0.01).toBeTruthy();
+        expect(float4Arr[1]).toBe(null);
+        expect(Math.abs(float4Arr[2]! - 3.3) < 0.01).toBeTruthy();
+        expect(row.arrnumeric || row.ArrNumeric).toEqual([
           '10.5',
           null,
           '30.125',
         ]);
-        assert.deepStrictEqual(row.arrtext || row.ArrText, [
-          'alpha',
-          null,
-          'gamma',
-        ]);
-        assert.deepStrictEqual(row.arrdate || row.ArrDate, [
+        expect(row.arrtext || row.ArrText).toEqual(['alpha', null, 'gamma']);
+        expect(row.arrdate || row.ArrDate).toEqual([
           '2026-01-01',
           null,
           '2026-06-01',
         ]);
         const tsArr = (row.arrtimestamp || row.ArrTimestamp) as (Date | null)[];
-        assert.ok(tsArr[0] instanceof Date);
-        assert.strictEqual(tsArr[1], null);
-        assert.ok(tsArr[2] instanceof Date);
-        assert.deepStrictEqual(row.arrjsonb || row.ArrJsonb, [
+        expect(tsArr[0] instanceof Date).toBeTruthy();
+        expect(tsArr[1]).toBe(null);
+        expect(tsArr[2] instanceof Date).toBeTruthy();
+        expect(row.arrjsonb || row.ArrJsonb).toEqual([
           {k: 'v1'},
           null,
           {k: 'v3'},
         ]);
-        assert.deepStrictEqual(row.arruuid || row.ArrUuid, [
+        expect(row.arruuid || row.ArrUuid).toEqual([
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           null,
           'b1ffcd00-0d1c-5fa9-cc7e-7cc0ce491b22',
@@ -953,33 +890,24 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT SingerId, FirstName FROM Singers WHERE SingerId = $1',
           [customSingerId],
         );
-        assert.strictEqual(res1.rowCount, 1);
-        assert.strictEqual(
-          res1.rows[0].firstname || res1.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res1.rowCount).toBe(1);
+        expect(res1.rows[0].firstname || res1.rows[0].FirstName).toBe('Marc');
 
         // Array parameter with .toPostgres() elements inside array
         const res2 = await client.query(
           'SELECT SingerId, LastName FROM Singers WHERE LastName = ANY($1) ORDER BY SingerId',
           [[customItem1, customItem2]],
         );
-        assert.strictEqual(res2.rowCount, 2);
-        assert.strictEqual(
-          res2.rows[0].lastname || res2.rows[0].LastName,
-          'Richards',
-        );
-        assert.strictEqual(
-          res2.rows[1].lastname || res2.rows[1].LastName,
-          'Smith',
-        );
+        expect(res2.rowCount).toBe(2);
+        expect(res2.rows[0].lastname || res2.rows[0].LastName).toBe('Richards');
+        expect(res2.rows[1].lastname || res2.rows[1].LastName).toBe('Smith');
 
         // Array value returned from .toPostgres()
         const res3 = await client.query(
           'SELECT SingerId, FirstName FROM Singers WHERE SingerId = ANY($1)',
           [{toPostgres: () => [1, 2]}],
         );
-        assert.strictEqual(res3.rowCount, 2);
+        expect(res3.rowCount).toBe(2);
       });
 
       it('should query AllTypes rows using array membership filter ($1 = ANY(ArrUuid))', async () => {
@@ -987,9 +915,9 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT Id FROM AllTypes WHERE $1 = ANY(ArrUuid) ORDER BY Id',
           ['a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'],
         );
-        assert.strictEqual(res.rowCount, 2); // Rows 1 and 4 have this UUID in ArrUuid
-        assert.strictEqual(String(res.rows[0].id || res.rows[0].Id), '1');
-        assert.strictEqual(String(res.rows[1].id || res.rows[1].Id), '4');
+        expect(res.rowCount).toBe(2); // Rows 1 and 4 have this UUID in ArrUuid
+        expect(String(res.rows[0].id || res.rows[0].Id)).toBe('1');
+        expect(String(res.rows[1].id || res.rows[1].Id)).toBe('4');
       });
 
       it('should query AllTypes rows using numeric array membership filter ($1 = ANY(ArrInt8))', async () => {
@@ -997,50 +925,47 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           'SELECT Id FROM AllTypes WHERE $1 = ANY(ArrInt8)',
           [200],
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(String(res.rows[0].id || res.rows[0].Id), '1');
+        expect(res.rowCount).toBe(1);
+        expect(String(res.rows[0].id || res.rows[0].Id)).toBe('1');
       });
     });
 
     describe('Field Metadata & PostgreSQL Catalog OIDs', () => {
       it('should map Spanner column metadata to exact PostgreSQL catalog OIDs (BuiltinOids)', async () => {
         const res = await client.query('SELECT * FROM AllTypes WHERE Id = 1');
-        assert.strictEqual(res.rowCount, 1);
-        assert.ok(res.fields && res.fields.length > 0);
+        expect(res.rowCount).toBe(1);
+        expect(res.fields && res.fields.length > 0).toBeTruthy();
 
         const fieldMap = new Map(
           res.fields.map(f => [f.name.toLowerCase(), f.dataTypeID]),
         );
 
         // Assert scalar PostgreSQL OIDs from table
-        assert.strictEqual(fieldMap.get('id'), BuiltinOids.INT8);
-        assert.strictEqual(fieldMap.get('colbool'), BuiltinOids.BOOL);
-        assert.strictEqual(fieldMap.get('colbytea'), BuiltinOids.BYTEA);
-        assert.strictEqual(fieldMap.get('colint8'), BuiltinOids.INT8);
-        assert.strictEqual(fieldMap.get('colfloat4'), BuiltinOids.FLOAT4);
-        assert.strictEqual(fieldMap.get('colfloat8'), BuiltinOids.FLOAT8);
-        assert.strictEqual(fieldMap.get('colnumeric'), BuiltinOids.NUMERIC);
-        assert.strictEqual(fieldMap.get('coltext'), BuiltinOids.TEXT);
-        assert.strictEqual(fieldMap.get('coldate'), BuiltinOids.DATE);
-        assert.strictEqual(
-          fieldMap.get('coltimestamp'),
-          BuiltinOids.TIMESTAMPTZ,
-        );
-        assert.strictEqual(fieldMap.get('coljsonb'), BuiltinOids.JSONB);
-        assert.strictEqual(fieldMap.get('coluuid'), BuiltinOids.UUID);
+        expect(fieldMap.get('id')).toBe(BuiltinOids.INT8);
+        expect(fieldMap.get('colbool')).toBe(BuiltinOids.BOOL);
+        expect(fieldMap.get('colbytea')).toBe(BuiltinOids.BYTEA);
+        expect(fieldMap.get('colint8')).toBe(BuiltinOids.INT8);
+        expect(fieldMap.get('colfloat4')).toBe(BuiltinOids.FLOAT4);
+        expect(fieldMap.get('colfloat8')).toBe(BuiltinOids.FLOAT8);
+        expect(fieldMap.get('colnumeric')).toBe(BuiltinOids.NUMERIC);
+        expect(fieldMap.get('coltext')).toBe(BuiltinOids.TEXT);
+        expect(fieldMap.get('coldate')).toBe(BuiltinOids.DATE);
+        expect(fieldMap.get('coltimestamp')).toBe(BuiltinOids.TIMESTAMPTZ);
+        expect(fieldMap.get('coljsonb')).toBe(BuiltinOids.JSONB);
+        expect(fieldMap.get('coluuid')).toBe(BuiltinOids.UUID);
 
         // Assert Array OIDs from table
-        assert.strictEqual(fieldMap.get('arrbool'), 1000);
-        assert.strictEqual(fieldMap.get('arrbytea'), 1001);
-        assert.strictEqual(fieldMap.get('arrint8'), 1016);
-        assert.strictEqual(fieldMap.get('arrfloat4'), 1021);
-        assert.strictEqual(fieldMap.get('arrfloat8'), 1022);
-        assert.strictEqual(fieldMap.get('arrnumeric'), 1231);
-        assert.strictEqual(fieldMap.get('arrtext'), 1009);
-        assert.strictEqual(fieldMap.get('arrdate'), 1182);
-        assert.strictEqual(fieldMap.get('arrtimestamp'), 1185);
-        assert.strictEqual(fieldMap.get('arrjsonb'), 3807);
-        assert.strictEqual(fieldMap.get('arruuid'), 2951);
+        expect(fieldMap.get('arrbool')).toBe(1000);
+        expect(fieldMap.get('arrbytea')).toBe(1001);
+        expect(fieldMap.get('arrint8')).toBe(1016);
+        expect(fieldMap.get('arrfloat4')).toBe(1021);
+        expect(fieldMap.get('arrfloat8')).toBe(1022);
+        expect(fieldMap.get('arrnumeric')).toBe(1231);
+        expect(fieldMap.get('arrtext')).toBe(1009);
+        expect(fieldMap.get('arrdate')).toBe(1182);
+        expect(fieldMap.get('arrtimestamp')).toBe(1185);
+        expect(fieldMap.get('arrjsonb')).toBe(3807);
+        expect(fieldMap.get('arruuid')).toBe(2951);
 
         // Assert interval OID via expression query
         const ivalRes = await client.query(
@@ -1049,7 +974,7 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const ivalFields = new Map(
           ivalRes.fields.map(f => [f.name.toLowerCase(), f.dataTypeID]),
         );
-        assert.strictEqual(ivalFields.get('ival'), BuiltinOids.INTERVAL);
+        expect(ivalFields.get('ival')).toBe(BuiltinOids.INTERVAL);
       });
     });
   });
@@ -1060,13 +985,10 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         const res = await client.query(
           'SELECT SingerId, FirstName FROM Singers WHERE SingerId = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(typeof res.rows[0], 'object');
-        assert.strictEqual(Array.isArray(res.rows[0]), false);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(typeof res.rows[0]).toBe('object');
+        expect(Array.isArray(res.rows[0])).toBe(false);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       });
 
       it('should format rows as positional arrays when rowMode is array', async () => {
@@ -1074,8 +996,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
           text: 'SELECT SingerId, FirstName, LastName, Tags FROM Singers WHERE SingerId = 1',
           rowMode: 'array',
         });
-        assert.strictEqual(res.rowCount, 1);
-        assert.deepStrictEqual(res.rows[0], [
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0]).toEqual([
           '1',
           'Marc',
           'Richards',
@@ -1092,25 +1014,25 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
 
         void q.on('fields', fields => {
           fieldsReceived = true;
-          assert.ok(fields.length >= 2);
+          expect(fields.length >= 2).toBeTruthy();
         });
         void q.on('row', (row, currentResult) => {
           rows.push(row);
-          assert.ok(currentResult);
-          assert.ok(currentResult.fields.length >= 2);
+          expect(currentResult).toBeTruthy();
+          expect(currentResult.fields.length >= 2).toBeTruthy();
         });
 
         const res = (await q) as QueryResult;
-        assert.strictEqual(fieldsReceived, true);
-        assert.strictEqual(rows.length >= 2, true);
-        assert.deepStrictEqual(res.rows, rows);
+        expect(fieldsReceived).toBe(true);
+        expect(rows.length >= 2).toBe(true);
+        expect(res.rows).toEqual(rows);
       });
     });
 
     describe('Transactions (BEGIN / COMMIT / ROLLBACK)', () => {
       it('should insert a singer in a transaction and COMMIT', async () => {
         await client.query('BEGIN');
-        assert.strictEqual(client.txStatus, 'T');
+        expect(client.txStatus).toBe('T');
 
         await client.query(`
           INSERT INTO Singers (SingerId, FirstName, LastName, Active)
@@ -1118,21 +1040,18 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         `);
 
         await client.query('COMMIT');
-        assert.strictEqual(client.txStatus, 'I');
+        expect(client.txStatus).toBe('I');
 
         const res = await client.query(
           'SELECT FirstName FROM Singers WHERE SingerId = 3',
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Alice',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Alice');
       });
 
       it('should rollback transaction and not persist rows on ROLLBACK', async () => {
         await client.query('BEGIN');
-        assert.strictEqual(client.txStatus, 'T');
+        expect(client.txStatus).toBe('T');
 
         await client.query(`
           INSERT INTO Singers (SingerId, FirstName, LastName, Active)
@@ -1140,29 +1059,29 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         `);
 
         await client.query('ROLLBACK');
-        assert.strictEqual(client.txStatus, 'I');
+        expect(client.txStatus).toBe('I');
 
         const res = await client.query(
           'SELECT * FROM Singers WHERE SingerId = 4',
         );
-        assert.strictEqual(res.rowCount, 0);
+        expect(res.rowCount).toBe(0);
       });
 
       // Currently this test is failing as node wrapper is not returning transaction state in case of error.
       it.skip('should transition txStatus to E on error inside transaction and reset to I on ROLLBACK', async () => {
         await client.query('BEGIN');
-        assert.strictEqual(client.txStatus, 'T');
+        expect(client.txStatus).toBe('T');
 
         try {
           // Trigger an error inside the active transaction
           await client.query('SELECT * FROM non_existent_table_for_tx_test');
-          assert.fail('Should have thrown error on non-existent table');
+          throw new Error('Should have thrown error on non-existent table');
         } catch {
-          assert.strictEqual(client.txStatus, 'E');
+          expect(client.txStatus).toBe('E');
         }
 
         await client.query('ROLLBACK');
-        assert.strictEqual(client.txStatus, 'I');
+        expect(client.txStatus).toBe('I');
       });
     });
   });
@@ -1170,17 +1089,14 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
   describe('Connection Pool (Pool Class)', () => {
     it('should acquire client, execute query and release back to pool', async () => {
       const clientFromPool = await pool.connect();
-      assert.ok(clientFromPool);
+      expect(clientFromPool).toBeTruthy();
 
       try {
         const res = await clientFromPool.query(
           'SELECT SingerId, FirstName FROM Singers WHERE SingerId = 1',
         );
-        assert.strictEqual(res.rowCount, 1);
-        assert.strictEqual(
-          res.rows[0].firstname || res.rows[0].FirstName,
-          'Marc',
-        );
+        expect(res.rowCount).toBe(1);
+        expect(res.rows[0].firstname || res.rows[0].FirstName).toBe('Marc');
       } finally {
         await clientFromPool.release();
       }
@@ -1188,10 +1104,10 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
 
     it('should execute direct query via pool.query()', async () => {
       const res = await pool.query('SELECT count(*) as total FROM Singers');
-      assert.strictEqual(res.rowCount, 1);
-      assert.ok(
+      expect(res.rowCount).toBe(1);
+      expect(
         Number(res.rows[0].total) >= 2 || Number(res.rows[0].count) >= 2,
-      );
+      ).toBeTruthy();
     });
 
     it('should format pool query results as positional arrays when rowMode is array', async () => {
@@ -1199,8 +1115,8 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
         text: 'SELECT SingerId, FirstName FROM Singers WHERE SingerId = 1',
         rowMode: 'array',
       });
-      assert.strictEqual(res.rowCount, 1);
-      assert.deepStrictEqual(res.rows[0], ['1', 'Marc']);
+      expect(res.rowCount).toBe(1);
+      expect(res.rows[0]).toEqual(['1', 'Marc']);
     });
 
     it('should execute concurrent queries via pool', async () => {
@@ -1217,10 +1133,10 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
       ];
 
       const results = await Promise.all(queries);
-      assert.strictEqual(results.length, 3);
-      assert.strictEqual(results[0].rowCount, 1);
-      assert.strictEqual(results[1].rowCount, 1);
-      assert.strictEqual(results[2].rowCount, 1);
+      expect(results.length).toBe(3);
+      expect(results[0].rowCount).toBe(1);
+      expect(results[1].rowCount).toBe(1);
+      expect(results[2].rowCount).toBe(1);
     });
 
     it('should stream rows and fields events via pool.query()', async () => {
@@ -1231,20 +1147,20 @@ describe('Spanner Driver System Tests (PostgreSQL Dialect)', function () {
 
       void q.on('fields', fields => {
         fieldsReceived = true;
-        assert.ok(fields.length >= 2);
+        expect(fields.length >= 2).toBeTruthy();
       });
       void q.on('row', (row, result) => {
         rows.push(row);
         lastResult = result;
-        assert.ok(result);
-        assert.ok(result.fields.length >= 2);
+        expect(result).toBeTruthy();
+        expect(result.fields.length >= 2).toBeTruthy();
       });
 
       const res = (await q) as QueryResult;
-      assert.strictEqual(fieldsReceived, true);
-      assert.strictEqual(rows.length >= 2, true);
-      assert.ok(lastResult);
-      assert.deepStrictEqual(res.rows, rows);
+      expect(fieldsReceived).toBe(true);
+      expect(rows.length >= 2).toBe(true);
+      expect(lastResult).toBeTruthy();
+      expect(res.rows).toEqual(rows);
     });
   });
 });

--- a/handwritten/spanner-driver/test/unit/client_test.ts
+++ b/handwritten/spanner-driver/test/unit/client_test.ts
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {afterEach, beforeEach, describe, it} from 'mocha';
-import * as sinon from 'sinon';
 import {Client, DatabaseError, Query, QueryResult} from '../../src/index.js';
 import {Pool as NativePool} from '../../src/lib/native.js';
 import {createMockPool} from './mock_native.js';
@@ -27,18 +24,24 @@ describe('Client Class', () => {
         instance: 'i',
         database: 'd',
       });
-      assert.strictEqual(client1.dsn, 'projects/p/instances/i/databases/d');
+      expect(client1.dsn).toBe('projects/p/instances/i/databases/d');
 
       const client2 = new Client('projects/p/instances/i/databases/d');
-      assert.strictEqual(client2.dsn, 'projects/p/instances/i/databases/d');
+      expect(client2.dsn).toBe('projects/p/instances/i/databases/d');
     });
 
     it('should invoke callback with error when client.connect(cb) fails on invalid config', done => {
       const client = new Client({});
       client.connect(err => {
-        assert.strictEqual(err instanceof DatabaseError, true);
-        assert.match(err!.message, /Invalid Spanner connection configuration/);
-        done();
+        try {
+          expect(err instanceof DatabaseError).toBe(true);
+          expect(err!.message).toMatch(
+            /Invalid Spanner connection configuration/,
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -50,11 +53,11 @@ describe('Client Class', () => {
       });
       try {
         await client.query('');
-        assert.fail('Should have thrown error');
+        throw new Error('Should have thrown error');
       } catch (err: unknown) {
-        assert.strictEqual(err instanceof DatabaseError, true);
+        expect(err instanceof DatabaseError).toBe(true);
         const dbErr = err as DatabaseError;
-        assert.strictEqual(dbErr.code, 'XX000');
+        expect(dbErr.code).toBe('XX000');
       } finally {
         await client.end();
       }
@@ -69,11 +72,11 @@ describe('Client Class', () => {
       try {
         // @ts-expect-error Testing runtime invalid values argument
         await client.query('SELECT $1', 'not-an-array');
-        assert.fail('Should have thrown error');
+        throw new Error('Should have thrown error');
       } catch (err: unknown) {
-        assert.strictEqual(err instanceof DatabaseError, true);
+        expect(err instanceof DatabaseError).toBe(true);
         const dbErr = err as DatabaseError;
-        assert.strictEqual(dbErr.code, 'XX000');
+        expect(dbErr.code).toBe('XX000');
       } finally {
         await client.end();
       }
@@ -97,11 +100,7 @@ describe('Client Class', () => {
 
       await Promise.all([client.connect(), client.connect(), client.connect()]);
 
-      assert.strictEqual(
-        connectInvocations,
-        1,
-        'concurrent connect() calls should only initiate connection once',
-      );
+      expect(connectInvocations).toBe(1);
     });
 
     it('should handle multiple client.end() calls safely without error', async () => {
@@ -111,7 +110,7 @@ describe('Client Class', () => {
         database: 'd',
       });
       await client.end();
-      await assert.doesNotReject(async () => client.end());
+      await expect(client.end()).resolves.not.toThrow();
     });
 
     it('should clear pending query queue when client.end() is called', async () => {
@@ -127,11 +126,9 @@ describe('Client Class', () => {
       await client.end();
 
       // Verify queue was emptied
-      assert.strictEqual(
+      expect(
         (client as unknown as {queryQueue: unknown[]}).queryQueue.length,
-        0,
-        'query queue should be emptied when client is closed',
-      );
+      ).toBe(0);
       try {
         await p1;
       } catch {
@@ -164,12 +161,11 @@ describe('Client Class', () => {
       await client.end();
       finishConnect();
 
-      assert.strictEqual(
+      expect(
         (client as unknown as {queryQueue: unknown[]}).queryQueue.length,
-        0,
-      );
-      await assert.rejects(async () => p2, /Client was closed/);
-      await assert.rejects(async () => p3, /Client was closed/);
+      ).toBe(0);
+      await expect(p2).rejects.toThrow(/Client was closed/);
+      await expect(p3).rejects.toThrow(/Client was closed/);
     });
 
     it('should delegate release() to end()', async () => {
@@ -179,9 +175,9 @@ describe('Client Class', () => {
         database: 'd',
       });
       (client as unknown as {isConnected: boolean}).isConnected = true;
-      assert.strictEqual(client.isConnected, true);
+      expect(client.isConnected).toBe(true);
       await client.release();
-      assert.strictEqual(client.isConnected, false);
+      expect(client.isConnected).toBe(false);
     });
 
     it('should delegate release(cb) to end(cb) using callback syntax', done => {
@@ -192,9 +188,13 @@ describe('Client Class', () => {
       });
       (client as unknown as {isConnected: boolean}).isConnected = true;
       client.release(err => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(client.isConnected, false);
-        done();
+        try {
+          expect(err).toBeNull();
+          expect(client.isConnected).toBe(false);
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -202,9 +202,15 @@ describe('Client Class', () => {
       const client = new Client({});
       const q = client.query('SELECT 1');
       void q.on('error', err => {
-        assert.strictEqual(err instanceof DatabaseError, true);
-        assert.match(err.message, /Invalid Spanner connection configuration/);
-        done();
+        try {
+          expect(err instanceof DatabaseError).toBe(true);
+          expect(err.message).toMatch(
+            /Invalid Spanner connection configuration/,
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
       void q.catch(() => {});
     });
@@ -226,25 +232,21 @@ describe('Client Class', () => {
         setTimeout(resolve, 50);
       });
 
-      assert.strictEqual(
-        errorEventEmitted,
-        true,
-        'error event should be emitted even when listener is attached immediately after client.query() returns',
-      );
+      expect(errorEventEmitted).toBe(true);
     });
   });
 
   describe('Mock Native Bridge Execution (End-to-End Query & State Flow)', () => {
-    let poolStub: sinon.SinonStub;
+    let poolSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      poolStub = sinon
-        .stub(NativePool, 'create')
-        .callsFake(async () => createMockPool());
+      poolSpy = jest
+        .spyOn(NativePool, 'create')
+        .mockImplementation(async () => createMockPool());
     });
 
     afterEach(() => {
-      poolStub.restore();
+      poolSpy.mockRestore();
     });
 
     it('should connect and close Client', async () => {
@@ -254,15 +256,14 @@ describe('Client Class', () => {
         database: 'd',
       });
       await client.connect();
-      assert.strictEqual(client.isConnected, true);
+      expect(client.isConnected).toBe(true);
       // Calling connect() on an already connected client should reject matching node-postgres
-      await assert.rejects(
-        client.connect(),
+      await expect(client.connect()).rejects.toThrow(
         /Client has already been connected/,
       );
-      assert.strictEqual(client.isConnected, true);
+      expect(client.isConnected).toBe(true);
       await client.end();
-      assert.strictEqual(client.isConnected, false);
+      expect(client.isConnected).toBe(false);
     });
 
     it('should connect using callback syntax', done => {
@@ -272,12 +273,20 @@ describe('Client Class', () => {
         database: 'd',
       });
       client.connect(err => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(client.isConnected, true);
-        client.end(() => {
-          assert.strictEqual(client.isConnected, false);
-          done();
-        });
+        try {
+          expect(err).toBeNull();
+          expect(client.isConnected).toBe(true);
+          client.end(() => {
+            try {
+              expect(client.isConnected).toBe(false);
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -294,9 +303,8 @@ describe('Client Class', () => {
       } catch {
         // Ignored if race rejected
       }
-      assert.strictEqual(client.isConnected, false);
-      await assert.rejects(
-        async () => client.connect(),
+      expect(client.isConnected).toBe(false);
+      await expect(client.connect()).rejects.toThrow(
         /Client was (already )?closed/,
       );
     });
@@ -308,10 +316,10 @@ describe('Client Class', () => {
         database: 'd',
       });
       const res = await client.query('SELECT 1');
-      assert.strictEqual(res.command, 'SELECT');
-      assert.strictEqual(res.rowCount, 1);
-      assert.deepStrictEqual(res.rows, [{'?column?': '1'}]);
-      assert.strictEqual(res.fields.length, 1);
+      expect(res.command).toBe('SELECT');
+      expect(res.rowCount).toBe(1);
+      expect(res.rows).toEqual([{fieldCount: undefined, '?column?': '1'}]);
+      expect(res.fields.length).toBe(1);
       await client.end();
     });
 
@@ -322,9 +330,16 @@ describe('Client Class', () => {
         database: 'd',
       });
       void client.query('SELECT 1', (err, res) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(res?.command, 'SELECT');
-        void client.end().then(() => done());
+        try {
+          expect(err).toBeNull();
+          expect(res?.command).toBe('SELECT');
+          void client
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -336,9 +351,16 @@ describe('Client Class', () => {
       });
       const q = new Query<QueryResult>('SELECT $1', [42]);
       void client.query(q, [42], (err, res) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(res?.command, 'SELECT');
-        void client.end().then(() => done());
+        try {
+          expect(err).toBeNull();
+          expect(res?.command).toBe('SELECT');
+          void client
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -358,18 +380,14 @@ describe('Client Class', () => {
 
       await new Promise<void>(resolve => {
         void client.query(q, undefined, err => {
-          assert.strictEqual(err instanceof DatabaseError, true);
+          expect(err instanceof DatabaseError).toBe(true);
           callbackInvoked = true;
           setTimeout(resolve, 20);
         });
       });
 
-      assert.strictEqual(
-        errorEventEmitted,
-        false,
-        'error event should not be emitted when callback is provided',
-      );
-      assert.strictEqual(callbackInvoked, true);
+      expect(errorEventEmitted).toBe(false);
+      expect(callbackInvoked).toBe(true);
       await client.end();
     });
 
@@ -380,19 +398,18 @@ describe('Client Class', () => {
         database: 'd',
       });
       await client.connect();
-      assert.strictEqual(client.isConnected, true);
+      expect(client.isConnected).toBe(true);
       await client.end();
-      assert.strictEqual(client.isConnected, false);
+      expect(client.isConnected).toBe(false);
 
       try {
         await client.query('SELECT 1');
-        assert.fail(
+        throw new Error(
           'Should have thrown an error when querying an ended client',
         );
       } catch (err: unknown) {
-        assert.strictEqual(client.isConnected, false);
-        assert.match(
-          (err as Error).message,
+        expect(client.isConnected).toBe(false);
+        expect((err as Error).message).toMatch(
           /Client has already been connected|Connection terminated|Client was closed/,
         );
       }
@@ -408,8 +425,7 @@ describe('Client Class', () => {
       (client as unknown as {nativeConnection: unknown}).nativeConnection =
         undefined;
 
-      await assert.rejects(
-        async () => client.query('SELECT 1'),
+      await expect(client.query('SELECT 1')).rejects.toThrow(
         /Connection terminated/,
       );
       await client.end();
@@ -424,12 +440,23 @@ describe('Client Class', () => {
       let endEventEmitted = false;
       const q = client.query('SELECT 1');
       void q.on('end', res => {
-        endEventEmitted = true;
-        assert.strictEqual(res.command, 'SELECT');
-        void client.end().then(() => {
-          assert.strictEqual(endEventEmitted, true);
-          done();
-        });
+        try {
+          endEventEmitted = true;
+          expect(res.command).toBe('SELECT');
+          void client
+            .end()
+            .then(() => {
+              try {
+                expect(endEventEmitted).toBe(true);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            })
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -441,8 +468,15 @@ describe('Client Class', () => {
       });
       const q = new Query<QueryResult>('FAIL_QUERY');
       void q.on('error', err => {
-        assert.strictEqual(err instanceof DatabaseError, true);
-        void client.end().then(() => done());
+        try {
+          expect(err instanceof DatabaseError).toBe(true);
+          void client
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
       void client.query(q).catch(() => {});
     });
@@ -454,12 +488,12 @@ describe('Client Class', () => {
         database: 'd',
       });
       const res = await client.query('SELECT 1');
-      assert.strictEqual(res.command, 'SELECT');
-      assert.strictEqual(res.rowCount, 1);
-      assert.strictEqual(res.fields.length, 1);
-      assert.strictEqual(res.fields[0].name, '?column?');
-      assert.strictEqual(res.rows.length, 1);
-      assert.deepStrictEqual(res.rows[0], {'?column?': '1'});
+      expect(res.command).toBe('SELECT');
+      expect(res.rowCount).toBe(1);
+      expect(res.fields.length).toBe(1);
+      expect(res.fields[0].name).toBe('?column?');
+      expect(res.rows.length).toBe(1);
+      expect(res.rows[0]).toEqual({'?column?': '1'});
       await client.end();
     });
 
@@ -475,16 +509,16 @@ describe('Client Class', () => {
       const q = client.query('SELECT 1');
       void q.on('fields', fields => {
         fieldsEmitted = true;
-        assert.strictEqual(fields.length, 1);
+        expect(fields.length).toBe(1);
       });
       void q.on('row', row => {
         receivedRows.push(row);
       });
 
       const res = await q;
-      assert.strictEqual(fieldsEmitted, true);
-      assert.strictEqual(receivedRows.length, 1);
-      assert.deepStrictEqual(res.rows, receivedRows);
+      expect(fieldsEmitted).toBe(true);
+      expect(receivedRows.length).toBe(1);
+      expect(res.rows).toEqual(receivedRows);
       await client.end();
     });
 
@@ -495,7 +529,7 @@ describe('Client Class', () => {
         database: 'd',
       });
       const res = await client.query('SELECT $1 as name', ['hello']);
-      assert.strictEqual(res.command, 'SELECT');
+      expect(res.command).toBe('SELECT');
       await client.end();
     });
 
@@ -509,9 +543,9 @@ describe('Client Class', () => {
         text: 'SELECT 1',
         rowMode: 'array',
       });
-      assert.strictEqual(res.command, 'SELECT');
-      assert.strictEqual(res.rowCount, 1);
-      assert.deepStrictEqual(res.rows, [['1']]);
+      expect(res.command).toBe('SELECT');
+      expect(res.rowCount).toBe(1);
+      expect(res.rows).toEqual([['1']]);
       await client.end();
     });
 
@@ -522,10 +556,10 @@ describe('Client Class', () => {
         database: 'd',
       });
       const res1 = await client.query('SELECT 1', []);
-      assert.strictEqual(res1.rowCount, 1);
+      expect(res1.rowCount).toBe(1);
 
       const res2 = await client.query('SELECT 1', undefined);
-      assert.strictEqual(res2.rowCount, 1);
+      expect(res2.rowCount).toBe(1);
       await client.end();
     });
 
@@ -536,27 +570,27 @@ describe('Client Class', () => {
         database: 'd',
       });
       await client.connect();
-      assert.strictEqual(client.txStatus, 'I');
-      assert.strictEqual(client.getTransactionStatus(), 'I');
+      expect(client.txStatus).toBe('I');
+      expect(client.getTransactionStatus()).toBe('I');
 
       // 1. BEGIN transaction -> 'T'
       await client.query('BEGIN');
-      assert.strictEqual(client.txStatus, 'T');
-      assert.strictEqual(client.getTransactionStatus(), 'T');
+      expect(client.txStatus).toBe('T');
+      expect(client.getTransactionStatus()).toBe('T');
 
       // 2. Query failure inside transaction -> 'E'
       try {
         await client.query('FAIL_QUERY');
-        assert.fail('Should have failed');
+        throw new Error('Should have failed');
       } catch {
-        assert.strictEqual(client.txStatus, 'E');
-        assert.strictEqual(client.getTransactionStatus(), 'E');
+        expect(client.txStatus).toBe('E');
+        expect(client.getTransactionStatus()).toBe('E');
       }
 
       // 3. ROLLBACK aborted transaction -> 'I'
       await client.query('ROLLBACK');
-      assert.strictEqual(client.txStatus, 'I');
-      assert.strictEqual(client.getTransactionStatus(), 'I');
+      expect(client.txStatus).toBe('I');
+      expect(client.getTransactionStatus()).toBe('I');
 
       await client.end();
     });
@@ -569,7 +603,7 @@ describe('Client Class', () => {
       });
       const customParser = (val: string) => `custom_${val}`;
       client.setTypeParser(16, customParser);
-      assert.strictEqual(client.getTypeParser(16), customParser);
+      expect(client.getTypeParser(16)).toBe(customParser);
     });
 
     it('should emit end event when client.end() is called', async () => {
@@ -584,8 +618,8 @@ describe('Client Class', () => {
         endEmitted = true;
       });
       await client.end();
-      assert.strictEqual(endEmitted, true);
-      assert.strictEqual(client.isEnded, true);
+      expect(endEmitted).toBe(true);
+      expect(client.isEnded).toBe(true);
     });
 
     it('should treat client.end() on unconnected client as a no-op that emits end without permanently closing', async () => {
@@ -599,11 +633,11 @@ describe('Client Class', () => {
         endEmitted = true;
       });
       await client.end();
-      assert.strictEqual(endEmitted, true);
-      assert.strictEqual(client.isEnded, false);
+      expect(endEmitted).toBe(true);
+      expect(client.isEnded).toBe(false);
       await client.connect();
       await client.end();
-      assert.strictEqual(client.isEnded, true);
+      expect(client.isEnded).toBe(true);
     });
   });
 });

--- a/handwritten/spanner-driver/test/unit/codec_test.ts
+++ b/handwritten/spanner-driver/test/unit/codec_test.ts
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {describe, it} from 'mocha';
 import {Codec} from '../../src/lib/codec.js';
 import {BuiltinOids} from '../../src/lib/pg/types.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import pkg from '@google-cloud/spanner-api/build/protos/protos.js';
+import * as pkg from '@google-cloud/spanner-api/build/protos/protos.js';
 import type {google as GoogleProto} from '@google-cloud/spanner-api/build/protos/protos.js';
 
-const {google} = pkg as {google: typeof GoogleProto};
+const google =
+  (pkg as unknown as {google: typeof GoogleProto}).google ||
+  (pkg as unknown as {default: {google: typeof GoogleProto}}).default?.google ||
+  (pkg as unknown as {default: typeof GoogleProto}).default;
 
 describe('Codec Utilities', () => {
   describe('mapMetadataToFieldDefs', () => {
     it('should return empty array for null/undefined metadata', () => {
-      assert.deepStrictEqual(Codec.mapMetadataToFieldDefs(null), []);
-      assert.deepStrictEqual(Codec.mapMetadataToFieldDefs(undefined), []);
-      assert.deepStrictEqual(Codec.mapMetadataToFieldDefs({}), []);
+      expect(Codec.mapMetadataToFieldDefs(null)).toEqual([]);
+      expect(Codec.mapMetadataToFieldDefs(undefined)).toEqual([]);
+      expect(Codec.mapMetadataToFieldDefs({})).toEqual([]);
     });
 
     it('should map Spanner scalar and array TypeCodes to PostgreSQL OIDs', () => {
@@ -63,17 +64,17 @@ describe('Codec Utilities', () => {
       };
 
       const fields = Codec.mapMetadataToFieldDefs(metadata, 'pg');
-      assert.strictEqual(fields.length, 11);
-      assert.strictEqual(fields[0].dataTypeID, BuiltinOids.BOOL);
-      assert.strictEqual(fields[1].dataTypeID, BuiltinOids.INT8);
-      assert.strictEqual(fields[2].dataTypeID, BuiltinOids.FLOAT8);
-      assert.strictEqual(fields[3].dataTypeID, BuiltinOids.TIMESTAMPTZ);
-      assert.strictEqual(fields[4].dataTypeID, BuiltinOids.DATE);
-      assert.strictEqual(fields[5].dataTypeID, BuiltinOids.TEXT);
-      assert.strictEqual(fields[6].dataTypeID, BuiltinOids.BYTEA);
-      assert.strictEqual(fields[7].dataTypeID, BuiltinOids.NUMERIC);
-      assert.strictEqual(fields[9].dataTypeID, 1016); // int8[]
-      assert.strictEqual(fields[10].dataTypeID, 1009); // text[]
+      expect(fields.length).toBe(11);
+      expect(fields[0].dataTypeID).toBe(BuiltinOids.BOOL);
+      expect(fields[1].dataTypeID).toBe(BuiltinOids.INT8);
+      expect(fields[2].dataTypeID).toBe(BuiltinOids.FLOAT8);
+      expect(fields[3].dataTypeID).toBe(BuiltinOids.TIMESTAMPTZ);
+      expect(fields[4].dataTypeID).toBe(BuiltinOids.DATE);
+      expect(fields[5].dataTypeID).toBe(BuiltinOids.TEXT);
+      expect(fields[6].dataTypeID).toBe(BuiltinOids.BYTEA);
+      expect(fields[7].dataTypeID).toBe(BuiltinOids.NUMERIC);
+      expect(fields[9].dataTypeID).toBe(1016); // int8[]
+      expect(fields[10].dataTypeID).toBe(1009); // text[]
     });
 
     it('should map GoogleSQL dialect types directly as strings', () => {
@@ -83,9 +84,8 @@ describe('Codec Utilities', () => {
         },
       };
       const fields = Codec.mapMetadataToFieldDefs(metadata, 'googlesql');
-      assert.strictEqual(fields.length, 1);
-      assert.strictEqual(
-        fields[0].dataTypeID,
+      expect(fields.length).toBe(1);
+      expect(fields[0].dataTypeID).toBe(
         String(google.spanner.v1.TypeCode.INT64),
       );
     });
@@ -93,9 +93,9 @@ describe('Codec Utilities', () => {
 
   describe('extractRawRow', () => {
     it('should return empty array for null/undefined ListValue', () => {
-      assert.deepStrictEqual(Codec.extractRawRow(null), []);
-      assert.deepStrictEqual(Codec.extractRawRow(undefined), []);
-      assert.deepStrictEqual(Codec.extractRawRow({}), []);
+      expect(Codec.extractRawRow(null)).toEqual([]);
+      expect(Codec.extractRawRow(undefined)).toEqual([]);
+      expect(Codec.extractRawRow({})).toEqual([]);
     });
 
     it('should extract values directly without unnecessary string conversions', () => {
@@ -112,72 +112,72 @@ describe('Codec Utilities', () => {
       };
 
       const raw = Codec.extractRawRow(listValue);
-      assert.strictEqual(raw[0], 'hello');
-      assert.strictEqual(raw[1], '123');
-      assert.strictEqual(raw[2], true);
-      assert.strictEqual(raw[3], false);
-      assert.strictEqual(raw[4], 45.6);
-      assert.strictEqual(raw[5], null);
-      assert.deepStrictEqual(raw[6], {k: 'v'});
+      expect(raw[0]).toBe('hello');
+      expect(raw[1]).toBe('123');
+      expect(raw[2]).toBe(true);
+      expect(raw[3]).toBe(false);
+      expect(raw[4]).toBe(45.6);
+      expect(raw[5]).toBeNull();
+      expect(raw[6]).toEqual({k: 'v'});
     });
   });
 
   describe('encodeValue & encodeParams', () => {
     it('should encode JavaScript primitives and complex objects into Spanner protobuf format', () => {
       // Booleans
-      assert.deepStrictEqual(Codec.encodeValue(true), {
+      expect(Codec.encodeValue(true)).toEqual({
         valueProto: {boolValue: true},
         typeProto: {code: google.spanner.v1.TypeCode.BOOL},
       });
 
       // Integers
-      assert.deepStrictEqual(Codec.encodeValue(42), {
+      expect(Codec.encodeValue(42)).toEqual({
         valueProto: {stringValue: '42'},
         typeProto: {code: google.spanner.v1.TypeCode.INT64},
       });
 
       // Floats
-      assert.deepStrictEqual(Codec.encodeValue(3.14), {
+      expect(Codec.encodeValue(3.14)).toEqual({
         valueProto: {numberValue: 3.14},
         typeProto: {code: google.spanner.v1.TypeCode.FLOAT64},
       });
 
       // BigInt
-      assert.deepStrictEqual(Codec.encodeValue(BigInt(9007199254740991)), {
+      expect(Codec.encodeValue(BigInt(9007199254740991))).toEqual({
         valueProto: {stringValue: '9007199254740991'},
         typeProto: {code: google.spanner.v1.TypeCode.INT64},
       });
 
       // Buffer
       const buf = Buffer.from('hello');
-      assert.deepStrictEqual(Codec.encodeValue(buf), {
+      expect(Codec.encodeValue(buf)).toEqual({
         valueProto: {stringValue: buf.toString('base64')},
         typeProto: {code: google.spanner.v1.TypeCode.BYTES},
       });
 
       // Dates
       const d = new Date('2023-01-01T00:00:00.000Z');
-      assert.deepStrictEqual(Codec.encodeValue(d), {
+      expect(Codec.encodeValue(d)).toEqual({
         valueProto: {stringValue: d.toISOString()},
         typeProto: {code: google.spanner.v1.TypeCode.TIMESTAMP},
       });
 
       // Invalid Date object -> nullValue
       const invalidDate = new Date('invalid');
-      assert.deepStrictEqual(Codec.encodeValue(invalidDate), {
+      expect(Codec.encodeValue(invalidDate)).toEqual({
         valueProto: {nullValue: google.protobuf.NullValue.NULL_VALUE},
         typeProto: {code: google.spanner.v1.TypeCode.TIMESTAMP},
       });
 
       // Objects / JSON
       const obj = {genre: 'rock'};
-      assert.deepStrictEqual(Codec.encodeValue(obj), {
+      expect(Codec.encodeValue(obj)).toEqual({
         valueProto: {stringValue: JSON.stringify(obj)},
         typeProto: {code: google.spanner.v1.TypeCode.STRING},
       });
 
       // Null / Undefined
-      assert.deepStrictEqual(Codec.encodeValue(null), {
+      expect(Codec.encodeValue(null)).toEqual({
         valueProto: {nullValue: google.protobuf.NullValue.NULL_VALUE},
         typeProto: {code: google.spanner.v1.TypeCode.TYPE_CODE_UNSPECIFIED},
       });
@@ -186,8 +186,8 @@ describe('Codec Utilities', () => {
     it('should encode arrays correctly', () => {
       // Empty array
       const emptyArr = Codec.encodeValue([]);
-      assert.deepStrictEqual(emptyArr.valueProto, {listValue: {values: []}});
-      assert.deepStrictEqual(emptyArr.typeProto, {
+      expect(emptyArr.valueProto).toEqual({listValue: {values: []}});
+      expect(emptyArr.typeProto).toEqual({
         code: google.spanner.v1.TypeCode.ARRAY,
         arrayElementType: {
           code: google.spanner.v1.TypeCode.TYPE_CODE_UNSPECIFIED,
@@ -196,12 +196,12 @@ describe('Codec Utilities', () => {
 
       // Integer array
       const intArr = Codec.encodeValue([1, 2, 3]);
-      assert.deepStrictEqual(intArr.valueProto, {
+      expect(intArr.valueProto).toEqual({
         listValue: {
           values: [{stringValue: '1'}, {stringValue: '2'}, {stringValue: '3'}],
         },
       });
-      assert.deepStrictEqual(intArr.typeProto, {
+      expect(intArr.typeProto).toEqual({
         code: google.spanner.v1.TypeCode.ARRAY,
         arrayElementType: {code: google.spanner.v1.TypeCode.INT64},
       });
@@ -210,10 +210,10 @@ describe('Codec Utilities', () => {
     it('should encode parameters via Codec.encodeParams supporting toPostgres custom objects', () => {
       const customParam = {toPostgres: () => 'custom_val'};
       const {fields} = Codec.encodeParams(['test', 123, true, customParam]);
-      assert.deepStrictEqual(fields.p1, {stringValue: 'test'});
-      assert.deepStrictEqual(fields.p2, {stringValue: '123'});
-      assert.deepStrictEqual(fields.p3, {boolValue: true});
-      assert.deepStrictEqual(fields.p4, {stringValue: 'custom_val'});
+      expect(fields.p1).toEqual({stringValue: 'test'});
+      expect(fields.p2).toEqual({stringValue: '123'});
+      expect(fields.p3).toEqual({boolValue: true});
+      expect(fields.p4).toEqual({stringValue: 'custom_val'});
     });
 
     it('should unwrap custom objects with .toPostgres() inside array parameters', () => {
@@ -222,7 +222,7 @@ describe('Codec Utilities', () => {
       const customId2 = {toPostgres: () => 102};
       // Pass array of custom objects to parameter $1
       const {fields} = Codec.encodeParams([[customId1, customId2]], 'pg');
-      assert.deepStrictEqual(fields.p1, {
+      expect(fields.p1).toEqual({
         listValue: {
           values: [{stringValue: '101'}, {stringValue: '102'}],
         },

--- a/handwritten/spanner-driver/test/unit/config_test.ts
+++ b/handwritten/spanner-driver/test/unit/config_test.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
 import {resolveDsn} from '../../src/lib/config.js';
 
 describe('resolveDsn', () => {
@@ -29,14 +28,14 @@ describe('resolveDsn', () => {
 
   it('should resolve standard Spanner DSN string directly', () => {
     const dsn = resolveDsn('projects/p/instances/i/databases/d');
-    assert.strictEqual(dsn, 'projects/p/instances/i/databases/d');
+    expect(dsn).toBe('projects/p/instances/i/databases/d');
   });
 
   it('should pass postgres connection URL straight through for Go driver extraction', () => {
     const url =
       'postgresql://user:pass@localhost:5432/projects/p/instances/i/databases/d?param=val';
     const dsn = resolveDsn(url);
-    assert.strictEqual(dsn, url);
+    expect(dsn).toBe(url);
   });
 
   it('should construct DSN from config object parts', () => {
@@ -45,7 +44,7 @@ describe('resolveDsn', () => {
       instance: 'i',
       database: 'd',
     });
-    assert.strictEqual(dsn, 'projects/p/instances/i/databases/d');
+    expect(dsn).toBe('projects/p/instances/i/databases/d');
   });
 
   it('should prioritize explicit cfg.project over process.env.GOOGLE_CLOUD_PROJECT', () => {
@@ -55,10 +54,7 @@ describe('resolveDsn', () => {
       instance: 'i',
       database: 'd',
     });
-    assert.strictEqual(
-      dsn,
-      'projects/explicit_project/instances/i/databases/d',
-    );
+    expect(dsn).toBe('projects/explicit_project/instances/i/databases/d');
   });
 
   it('should prepend custom host and port to resource path', () => {
@@ -69,10 +65,7 @@ describe('resolveDsn', () => {
       host: 'localhost',
       port: 9010,
     });
-    assert.strictEqual(
-      dsn,
-      'localhost:9010/projects/p/instances/i/databases/d',
-    );
+    expect(dsn).toBe('localhost:9010/projects/p/instances/i/databases/d');
   });
 
   it('should prepend custom host without port to resource path', () => {
@@ -82,16 +75,15 @@ describe('resolveDsn', () => {
       database: 'd',
       host: 'spanner.googleapis.com',
     });
-    assert.strictEqual(
-      dsn,
+    expect(dsn).toBe(
       'spanner.googleapis.com/projects/p/instances/i/databases/d',
     );
   });
 
   it('should return empty string for invalid/incomplete configurations on Node object level', () => {
     delete process.env.GOOGLE_CLOUD_PROJECT;
-    assert.strictEqual(resolveDsn({database: 'd'}), '');
-    assert.strictEqual(resolveDsn({}), '');
+    expect(resolveDsn({database: 'd'})).toBe('');
+    expect(resolveDsn({})).toBe('');
   });
 
   describe('environment variables', () => {
@@ -113,7 +105,7 @@ describe('resolveDsn', () => {
         instance: 'i',
         database: 'd',
       });
-      assert.strictEqual(dsn, 'projects/gcp-project/instances/i/databases/d');
+      expect(dsn).toBe('projects/gcp-project/instances/i/databases/d');
     });
   });
 });

--- a/handwritten/spanner-driver/test/unit/errors_test.ts
+++ b/handwritten/spanner-driver/test/unit/errors_test.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {describe, it} from 'mocha';
 import {enrichError, enrichPgError} from '../../src/lib/errors.js';
 
 describe('enrichPgError SQLSTATE Mapping', () => {
@@ -23,29 +21,28 @@ describe('enrichPgError SQLSTATE Mapping', () => {
         '[SQLSTATE 42P01] rpc error: code = NotFound desc = relation "foo" does not exist',
       ),
     );
-    assert.strictEqual(err.code, '42P01');
-    assert.strictEqual(err.severity, 'ERROR');
+    expect(err.code).toBe('42P01');
+    expect(err.severity).toBe('ERROR');
   });
 
   it('should preserve valid 5-character PostgreSQL SQLSTATE string codes', () => {
     const orig = new Error('custom error') as Error & {code?: string};
     orig.code = '42P01';
     const err = enrichPgError(orig);
-    assert.strictEqual(err.code, '42P01');
+    expect(err.code).toBe('42P01');
   });
 
   it('should fallback to XX000 for unknown errors without SQLSTATE prefix', () => {
     const err = enrichPgError(new Error('random unknown error message'));
-    assert.strictEqual(err.code, 'XX000');
-    assert.strictEqual(err.severity, 'ERROR');
+    expect(err.code).toBe('XX000');
+    expect(err.severity).toBe('ERROR');
   });
 
   it('should preserve stack traces when wrapping Error objects', () => {
     const orig = new Error('test stack preservation');
     orig.stack = 'CustomError: test\n    at testFunction (file.js:1:1)';
     const err = enrichPgError(orig);
-    assert.strictEqual(
-      err.stack,
+    expect(err.stack).toBe(
       'CustomError: test\n    at testFunction (file.js:1:1)',
     );
   });
@@ -56,14 +53,14 @@ describe('enrichPgError SQLSTATE Mapping', () => {
     };
     orig.code = 'EPERM';
     const err = enrichPgError(orig);
-    assert.strictEqual(err.code, 'XX000');
+    expect(err.code).toBe('XX000');
   });
 
   it('should handle gRPC numeric error codes and fallback to XX000', () => {
     const orig = {message: 'not found', code: 5};
     const err = enrichPgError(orig);
-    assert.strictEqual(err.code, 'XX000');
-    assert.strictEqual(err.message, 'not found');
+    expect(err.code).toBe('XX000');
+    expect(err.message).toBe('not found');
   });
 
   describe('enrichError dispatcher', () => {
@@ -73,7 +70,7 @@ describe('enrichPgError SQLSTATE Mapping', () => {
           '[SQLSTATE 42P01] rpc error: code = NotFound desc = relation "foo" does not exist',
         ),
       );
-      assert.strictEqual(err.code, '42P01');
+      expect(err.code).toBe('42P01');
     });
   });
 });

--- a/handwritten/spanner-driver/test/unit/mock_native.ts
+++ b/handwritten/spanner-driver/test/unit/mock_native.ts
@@ -15,10 +15,13 @@
 import type {Pool} from '../../src/lib/native.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import pkg from '@google-cloud/spanner-api/build/protos/protos.js';
+import * as pkg from '@google-cloud/spanner-api/build/protos/protos.js';
 import type {google as GoogleProto} from '@google-cloud/spanner-api/build/protos/protos.js';
 
-const {google} = pkg as {google: typeof GoogleProto};
+const google =
+  (pkg as unknown as {google: typeof GoogleProto}).google ||
+  (pkg as unknown as {default: {google: typeof GoogleProto}}).default?.google ||
+  (pkg as unknown as {default: typeof GoogleProto}).default;
 
 export class MockNativeRows {
   public oid = 1;

--- a/handwritten/spanner-driver/test/unit/pg_utilities_test.ts
+++ b/handwritten/spanner-driver/test/unit/pg_utilities_test.ts
@@ -12,25 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {describe, it} from 'mocha';
 import {escapeIdentifier, escapeLiteral} from '../../src/lib/pg/utilities.js';
 
 describe('PostgreSQL Dialect Utilities', () => {
   it('should escape PostgreSQL identifiers with double quotes', () => {
-    assert.strictEqual(escapeIdentifier('foo'), '"foo"');
-    assert.strictEqual(escapeIdentifier('my_table'), '"my_table"');
-    assert.strictEqual(escapeIdentifier('b"ar'), '"b""ar"');
+    expect(escapeIdentifier('foo')).toBe('"foo"');
+    expect(escapeIdentifier('my_table')).toBe('"my_table"');
+    expect(escapeIdentifier('b"ar')).toBe('"b""ar"');
   });
 
   it('should escape PostgreSQL string literals with single quotes', () => {
-    assert.strictEqual(escapeLiteral('hello'), "'hello'");
-    assert.strictEqual(escapeLiteral("O'Connor"), "'O''Connor'");
+    expect(escapeLiteral('hello')).toBe("'hello'");
+    expect(escapeLiteral("O'Connor")).toBe("'O''Connor'");
   });
 
   it('should escape backslashes using PostgreSQL E string syntax', () => {
-    assert.strictEqual(
-      escapeLiteral('C:\\path\\to\\file'),
+    expect(escapeLiteral('C:\\path\\to\\file')).toBe(
       "E'C:\\\\path\\\\to\\\\file'",
     );
   });

--- a/handwritten/spanner-driver/test/unit/pool_test.ts
+++ b/handwritten/spanner-driver/test/unit/pool_test.ts
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {afterEach, beforeEach, describe, it} from 'mocha';
-import * as sinon from 'sinon';
 import {Client, Pool, Query, QueryResult} from '../../src/index.js';
 import {Pool as NativePool} from '../../src/lib/native.js';
 import {createMockPool} from './mock_native.js';
@@ -27,29 +24,28 @@ describe('Pool Class', () => {
         instance: 'i',
         database: 'd',
       });
-      assert.strictEqual(pool1.config.project, 'p');
-      assert.strictEqual(pool1.dsn, 'projects/p/instances/i/databases/d');
+      expect(pool1.config.project).toBe('p');
+      expect(pool1.dsn).toBe('projects/p/instances/i/databases/d');
 
       const pool2 = new Pool('projects/p/instances/i/databases/d');
-      assert.strictEqual(
-        pool2.config.connectionString,
+      expect(pool2.config.connectionString).toBe(
         'projects/p/instances/i/databases/d',
       );
-      assert.strictEqual(pool2.dsn, 'projects/p/instances/i/databases/d');
+      expect(pool2.dsn).toBe('projects/p/instances/i/databases/d');
     });
   });
 
   describe('Mock Native Bridge Execution (End-to-End Pooling & Lifecycle)', () => {
-    let poolStub: sinon.SinonStub;
+    let poolSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      poolStub = sinon
-        .stub(NativePool, 'create')
-        .callsFake(async () => createMockPool());
+      poolSpy = jest
+        .spyOn(NativePool, 'create')
+        .mockImplementation(async () => createMockPool());
     });
 
     afterEach(() => {
-      poolStub.restore();
+      poolSpy.mockRestore();
     });
 
     it('should acquire client via connect() promise and return it to idle pool on release()', async () => {
@@ -59,28 +55,20 @@ describe('Pool Class', () => {
         database: 'd',
       });
       const client = await pool.connect();
-      assert.strictEqual(client.isConnected, true);
-      assert.strictEqual(typeof client.release, 'function');
-      assert.strictEqual(pool.totalCount, 1);
-      assert.strictEqual(pool.idleCount, 0);
+      expect(client.isConnected).toBe(true);
+      expect(typeof client.release).toBe('function');
+      expect(pool.totalCount).toBe(1);
+      expect(pool.idleCount).toBe(0);
 
       await client.release();
-      assert.strictEqual(
-        client.isConnected,
-        true,
-        'Client remains connected in idle pool',
-      );
-      assert.strictEqual(pool.idleCount, 1);
-      assert.strictEqual(pool.totalCount, 1);
+      expect(client.isConnected).toBe(true);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       await pool.end();
-      assert.strictEqual(pool.idleCount, 0);
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(
-        client.isConnected,
-        false,
-        'Client is closed when pool ends',
-      );
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(client.isConnected).toBe(false);
     });
 
     it('should reuse idle clients from the pool on subsequent connect() calls', async () => {
@@ -93,11 +81,7 @@ describe('Pool Class', () => {
       await client1.release();
 
       const client2 = await pool.connect();
-      assert.strictEqual(
-        client1,
-        client2,
-        'Should reuse the same client instance',
-      );
+      expect(client1).toBe(client2);
       await client2.release();
       await pool.end();
     });
@@ -112,8 +96,8 @@ describe('Pool Class', () => {
 
       const c1 = await pool.connect();
       const c2 = await pool.connect();
-      assert.strictEqual(pool.totalCount, 2);
-      assert.strictEqual(pool.idleCount, 0);
+      expect(pool.totalCount).toBe(2);
+      expect(pool.idleCount).toBe(0);
 
       let c3Acquired = false;
       let c3Client: Client | undefined;
@@ -123,19 +107,15 @@ describe('Pool Class', () => {
         return c;
       });
 
-      assert.strictEqual(pool.waitingCount, 1);
-      assert.strictEqual(c3Acquired, false);
+      expect(pool.waitingCount).toBe(1);
+      expect(c3Acquired).toBe(false);
 
       await c1.release();
       await p3;
 
-      assert.strictEqual(c3Acquired, true);
-      assert.strictEqual(
-        c3Client,
-        c1,
-        'Queued acquirer should receive released client',
-      );
-      assert.strictEqual(pool.waitingCount, 0);
+      expect(c3Acquired).toBe(true);
+      expect(c3Client).toBe(c1);
+      expect(pool.waitingCount).toBe(0);
 
       await c2.release();
       await c3Client!.release();
@@ -152,14 +132,13 @@ describe('Pool Class', () => {
       });
 
       const c1 = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
 
       try {
         await pool.connect();
-        assert.fail('Should have timed out waiting for connection');
+        throw new Error('Should have timed out waiting for connection');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
+        expect((err as Error).message).toBe(
           'timeout exceeded when trying to connect',
         );
       }
@@ -183,10 +162,9 @@ describe('Pool Class', () => {
 
       try {
         await pool.connect();
-        assert.fail('Should have timed out establishing connection');
+        throw new Error('Should have timed out establishing connection');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
+        expect((err as Error).message).toBe(
           'timeout exceeded when trying to connect',
         );
       } finally {
@@ -210,15 +188,14 @@ describe('Pool Class', () => {
 
       try {
         await pool.connect();
-        assert.fail('Should have timed out during onConnect');
+        throw new Error('Should have timed out during onConnect');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
+        expect((err as Error).message).toBe(
           'timeout exceeded when trying to connect',
         );
       }
 
-      assert.strictEqual(pool.totalCount, 0);
+      expect(pool.totalCount).toBe(0);
       await pool.end();
     });
 
@@ -232,12 +209,12 @@ describe('Pool Class', () => {
 
       const c1 = await pool.connect();
       await c1.release();
-      assert.strictEqual(pool.idleCount, 1);
+      expect(pool.idleCount).toBe(1);
 
       await new Promise(r => setTimeout(r, 80));
-      assert.strictEqual(pool.idleCount, 0);
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(c1.isConnected, false);
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(c1.isConnected).toBe(false);
 
       await pool.end();
     });
@@ -253,15 +230,11 @@ describe('Pool Class', () => {
 
       const c1 = await pool.connect();
       await c1.release();
-      assert.strictEqual(pool.idleCount, 1);
+      expect(pool.idleCount).toBe(1);
 
       await new Promise(r => setTimeout(r, 70));
-      assert.strictEqual(
-        pool.idleCount,
-        1,
-        'min idle client should be retained',
-      );
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       await pool.end();
     });
@@ -283,12 +256,7 @@ describe('Pool Class', () => {
       await c.release();
       await pool.end();
 
-      assert.deepStrictEqual(events, [
-        'connect',
-        'acquire',
-        'release',
-        'remove',
-      ]);
+      expect(events).toEqual(['connect', 'acquire', 'release', 'remove']);
     });
 
     it('should destroy client when released with error parameter', async () => {
@@ -299,12 +267,12 @@ describe('Pool Class', () => {
       });
 
       const c = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
 
       await c.release(new Error('Fatal error'));
-      assert.strictEqual(pool.idleCount, 0);
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(c.isConnected, false);
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(c.isConnected).toBe(false);
 
       await pool.end();
     });
@@ -318,7 +286,7 @@ describe('Pool Class', () => {
       });
 
       const c1 = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
 
       let waiterResolved = false;
       let newClient: Client | undefined;
@@ -328,21 +296,17 @@ describe('Pool Class', () => {
         return c;
       });
 
-      assert.strictEqual(pool.waitingCount, 1);
+      expect(pool.waitingCount).toBe(1);
 
       // Release c1 with fatal error -> removeClient destroys c1 and connects fresh replacement for waiter
       await c1.release(new Error('Connection lost'));
       await p2;
 
-      assert.strictEqual(waiterResolved, true);
-      assert.notStrictEqual(
-        newClient,
-        c1,
-        'Should instantiate a fresh new Client instance',
-      );
-      assert.strictEqual(newClient?.isConnected, true);
-      assert.strictEqual(pool.waitingCount, 0);
-      assert.strictEqual(pool.totalCount, 1);
+      expect(waiterResolved).toBe(true);
+      expect(newClient).not.toBe(c1);
+      expect(newClient?.isConnected).toBe(true);
+      expect(pool.waitingCount).toBe(0);
+      expect(pool.totalCount).toBe(1);
 
       await newClient!.release();
       await pool.end();
@@ -363,16 +327,11 @@ describe('Pool Class', () => {
       const c = await pool.connect();
       c.emit('error', new Error('Background connection dropped'));
 
-      assert.ok(receivedErr);
-      assert.strictEqual(
-        (receivedErr as Error).message,
+      expect(receivedErr).toBeTruthy();
+      expect((receivedErr as unknown as Error).message).toBe(
         'Background connection dropped',
       );
-      assert.strictEqual(
-        pool.totalCount,
-        0,
-        'Dead client should be removed from pool',
-      );
+      expect(pool.totalCount).toBe(0);
 
       await pool.end();
     });
@@ -387,11 +346,7 @@ describe('Pool Class', () => {
       const c = await pool.connect();
       // Should not throw or crash uncaught exception and should remove dead client
       c.emit('error', new Error('Background silent drop'));
-      assert.strictEqual(
-        pool.totalCount,
-        0,
-        'Dead client should be removed from pool',
-      );
+      expect(pool.totalCount).toBe(0);
 
       await pool.end();
     });
@@ -404,21 +359,17 @@ describe('Pool Class', () => {
       });
 
       const c = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
-      assert.strictEqual(pool.idleCount, 0);
+      expect(pool.totalCount).toBe(1);
+      expect(pool.idleCount).toBe(0);
 
       await c.release();
-      assert.strictEqual(pool.idleCount, 1);
+      expect(pool.idleCount).toBe(1);
 
       // Second and third release calls should safely no-op
       await c.release();
       await c.release();
-      assert.strictEqual(
-        pool.idleCount,
-        1,
-        'idleCount must not duplicate client',
-      );
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       await pool.end();
     });
@@ -434,7 +385,7 @@ describe('Pool Class', () => {
 
       const c = await pool.connect();
       await c.release();
-      assert.strictEqual(pool.idleCount, 1);
+      expect(pool.idleCount).toBe(1);
 
       await pool.end();
     });
@@ -449,19 +400,15 @@ describe('Pool Class', () => {
 
       const c1 = await pool.connect();
       await c1.release();
-      assert.strictEqual(pool.idleCount, 1);
+      expect(pool.idleCount).toBe(1);
 
       const c1Again = await pool.connect();
-      assert.strictEqual(c1, c1Again);
+      expect(c1).toBe(c1Again);
 
       await c1Again.release();
-      assert.strictEqual(
-        pool.idleCount,
-        0,
-        'Client should be destroyed after 2 uses',
-      );
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(c1.isConnected, false);
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(c1.isConnected).toBe(false);
 
       await pool.end();
     });
@@ -478,13 +425,9 @@ describe('Pool Class', () => {
       await new Promise(r => setTimeout(r, 60));
       await c1.release();
 
-      assert.strictEqual(
-        pool.idleCount,
-        0,
-        'Client should be destroyed due to maxLifetimeSeconds',
-      );
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(c1.isConnected, false);
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(c1.isConnected).toBe(false);
 
       await pool.end();
     });
@@ -501,26 +444,18 @@ describe('Pool Class', () => {
       const c1 = await pool.connect();
       // Released immediately while still young
       await c1.release();
-      assert.strictEqual(pool.idleCount, 1);
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       // Wait 60ms so client expires while sitting idle in pool
       await new Promise(r => setTimeout(r, 60));
 
       // Connect again -> should detect expired lifetime on checkout, evict c1, and create fresh c2
       const c2 = await pool.connect();
-      assert.notStrictEqual(
-        c1,
-        c2,
-        'Should create a fresh client rather than reusing expired idle client',
-      );
-      assert.strictEqual(
-        c1.isConnected,
-        false,
-        'Expired client should have been closed',
-      );
-      assert.strictEqual(c2.isConnected, true);
-      assert.strictEqual(pool.totalCount, 1);
+      expect(c1).not.toBe(c2);
+      expect(c1.isConnected).toBe(false);
+      expect(c2.isConnected).toBe(true);
+      expect(pool.totalCount).toBe(1);
 
       await c2.release();
       await pool.end();
@@ -534,12 +469,12 @@ describe('Pool Class', () => {
         database: 'd',
         onConnect: async client => {
           onConnectRan = true;
-          assert.strictEqual(client.isConnected, true);
+          expect(client.isConnected).toBe(true);
         },
       });
 
       const c1 = await pool.connect();
-      assert.strictEqual(onConnectRan, true);
+      expect(onConnectRan).toBe(true);
       await c1.release();
       await pool.end();
     });
@@ -556,15 +491,12 @@ describe('Pool Class', () => {
 
       try {
         await pool.connect();
-        assert.fail('Should have thrown onConnect error');
+        throw new Error('Should have thrown onConnect error');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
-          'onConnect initialization failed',
-        );
+        expect((err as Error).message).toBe('onConnect initialization failed');
       }
 
-      assert.strictEqual(pool.totalCount, 0);
+      expect(pool.totalCount).toBe(0);
       await pool.end();
     });
 
@@ -575,12 +507,19 @@ describe('Pool Class', () => {
         database: 'd',
       });
       pool.connect((err, client, releaseDone) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(client?.isConnected, true);
-        if (releaseDone) {
-          releaseDone();
+        try {
+          expect(err).toBe(null);
+          expect(client?.isConnected).toBe(true);
+          if (releaseDone) {
+            releaseDone();
+          }
+          void pool
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
         }
-        void pool.end().then(() => done());
       });
     });
 
@@ -591,14 +530,21 @@ describe('Pool Class', () => {
         database: 'd',
       });
       pool.connect((err, client, releaseDone) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(pool.totalCount, 1);
-        if (releaseDone) {
-          releaseDone(new Error('Fatal connection issue'));
+        try {
+          expect(err).toBe(null);
+          expect(pool.totalCount).toBe(1);
+          if (releaseDone) {
+            releaseDone(new Error('Fatal connection issue'));
+          }
+          expect(pool.totalCount).toBe(0);
+          expect(pool.idleCount).toBe(0);
+          void pool
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
         }
-        assert.strictEqual(pool.totalCount, 0);
-        assert.strictEqual(pool.idleCount, 0);
-        void pool.end().then(() => done());
       });
     });
 
@@ -609,10 +555,10 @@ describe('Pool Class', () => {
         database: 'd',
       });
       const res = await pool.query('SELECT 1');
-      assert.strictEqual(res.command, 'SELECT');
-      assert.strictEqual(res.rowCount, 1);
-      assert.deepStrictEqual(res.rows, [{'?column?': '1'}]);
-      assert.strictEqual(res.fields.length, 1);
+      expect(res.command).toBe('SELECT');
+      expect(res.rowCount).toBe(1);
+      expect(res.rows).toEqual([{'?column?': '1'}]);
+      expect(res.fields.length).toBe(1);
       await pool.end();
     });
 
@@ -623,9 +569,16 @@ describe('Pool Class', () => {
         database: 'd',
       });
       void pool.query('SELECT 1', (err, res) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(res?.command, 'SELECT');
-        void pool.end().then(() => done());
+        try {
+          expect(err).toBe(null);
+          expect(res?.command).toBe('SELECT');
+          void pool
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -637,8 +590,8 @@ describe('Pool Class', () => {
       });
       const q = new Query<QueryResult>('SELECT $1', [42]);
       void pool.query(q, [42], (err, res) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(res?.command, 'SELECT');
+        expect(err).toBe(null);
+        expect(res?.command).toBe('SELECT');
         void pool.end().then(() => done());
       });
     });
@@ -649,17 +602,23 @@ describe('Pool Class', () => {
       const pool = new Pool({});
       let callCount = 0;
       void pool.query('SELECT 1', (err, res) => {
-        if (originalProject !== undefined) {
-          process.env.GOOGLE_CLOUD_PROJECT = originalProject;
-        } else {
-          delete process.env.GOOGLE_CLOUD_PROJECT;
+        try {
+          if (originalProject !== undefined) {
+            process.env.GOOGLE_CLOUD_PROJECT = originalProject;
+          } else {
+            delete process.env.GOOGLE_CLOUD_PROJECT;
+          }
+          callCount++;
+          expect(res).toBe(undefined);
+          expect(callCount).toBe(1);
+          expect(err instanceof Error).toBe(true);
+          expect(err!.message).toMatch(
+            /Invalid Spanner connection configuration/,
+          );
+          done();
+        } catch (e) {
+          done(e);
         }
-        callCount++;
-        assert.strictEqual(res, undefined);
-        assert.strictEqual(callCount, 1);
-        assert.strictEqual(err instanceof Error, true);
-        assert.match(err!.message, /Invalid Spanner connection configuration/);
-        done();
       });
     });
 
@@ -680,18 +639,14 @@ describe('Pool Class', () => {
       await new Promise<void>(resolve => {
         void pool.query(q, undefined, (err, res) => {
           callCount++;
-          assert.strictEqual(res, undefined);
-          assert.strictEqual(callCount, 1);
-          assert.strictEqual(err instanceof Error, true);
+          expect(res).toBe(undefined);
+          expect(callCount).toBe(1);
+          expect(err instanceof Error).toBe(true);
           setTimeout(resolve, 20);
         });
       });
 
-      assert.strictEqual(
-        errorEventEmitted,
-        false,
-        'error event should not be emitted when callback is provided',
-      );
+      expect(errorEventEmitted).toBe(false);
       await pool.end();
     });
 
@@ -709,20 +664,16 @@ describe('Pool Class', () => {
 
       try {
         await pool.query('SELECT * FROM users');
-        assert.fail('Should have failed on query execution');
+        throw new Error('Should have failed on query execution');
       } catch (err: unknown) {
-        assert.strictEqual((err as Error).message, 'Table not found: users');
+        expect((err as Error).message).toBe('Table not found: users');
       } finally {
         Client.prototype.query = origQuery;
       }
 
       // Client should NOT be destroyed; it should be returned to idle pool
-      assert.strictEqual(
-        pool.idleCount,
-        1,
-        'Client should be returned to idle pool',
-      );
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       await pool.end();
     });
@@ -736,10 +687,9 @@ describe('Pool Class', () => {
       await pool.end();
       try {
         await pool.connect();
-        assert.fail('Should have thrown error on ending pool');
+        throw new Error('Should have thrown error on ending pool');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
+        expect((err as Error).message).toBe(
           'Cannot acquire client from ending pool',
         );
       }
@@ -764,16 +714,15 @@ describe('Pool Class', () => {
 
       try {
         await connectPromise;
-        assert.fail('connect() should have been rejected');
+        throw new Error('connect() should have been rejected');
       } catch (err: unknown) {
-        assert.strictEqual(
-          (err as Error).message,
+        expect((err as Error).message).toBe(
           'Cannot acquire client from ending pool',
         );
       }
 
       await endPromise;
-      assert.strictEqual(pool.totalCount, 0);
+      expect(pool.totalCount).toBe(0);
     });
 
     it('should reject pool.query() calls after pool.end() and invoke callback with error', done => {
@@ -782,14 +731,23 @@ describe('Pool Class', () => {
         instance: 'i',
         database: 'd',
       });
-      void pool.end().then(() => {
-        void pool.query('SELECT 1', (err, res) => {
-          assert.strictEqual(res, undefined);
-          assert.strictEqual(err instanceof Error, true);
-          assert.match(err!.message, /Cannot acquire client from ending pool/);
-          done();
-        });
-      });
+      void pool
+        .end()
+        .then(() => {
+          void pool.query('SELECT 1', (err, res) => {
+            try {
+              expect(res).toBe(undefined);
+              expect(err instanceof Error).toBe(true);
+              expect(err!.message).toMatch(
+                /Cannot acquire client from ending pool/,
+              );
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+        })
+        .catch(done);
     });
 
     it('should ensure client is released before user callback executes in pool.query()', done => {
@@ -824,14 +782,17 @@ describe('Pool Class', () => {
         };
 
       void pool.query('SELECT 1', (err, res) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(res?.command, 'SELECT');
-        assert.strictEqual(
-          clientReleased,
-          true,
-          'Client release must complete BEFORE user callback is executed',
-        );
-        void pool.end().then(() => done());
+        try {
+          expect(err).toBe(null);
+          expect(res?.command).toBe('SELECT');
+          expect(clientReleased).toBe(true);
+          void pool
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -854,8 +815,15 @@ describe('Pool Class', () => {
       });
       const q = new Query<QueryResult>('');
       void q.on('error', err => {
-        assert.strictEqual(err instanceof Error, true);
-        void pool.end().then(() => done());
+        try {
+          expect(err instanceof Error).toBe(true);
+          void pool
+            .end()
+            .then(() => done())
+            .catch(done);
+        } catch (e) {
+          done(e);
+        }
       });
       void pool.query(q).catch(() => {});
     });
@@ -864,8 +832,14 @@ describe('Pool Class', () => {
       const pool = new Pool({});
       const q = new Query<QueryResult>('SELECT 1');
       void q.on('error', err => {
-        assert.match(err.message, /Invalid Spanner connection configuration/);
-        done();
+        try {
+          expect(err.message).toMatch(
+            /Invalid Spanner connection configuration/,
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
       void pool.query(q).catch(() => {});
     });
@@ -902,11 +876,7 @@ describe('Pool Class', () => {
         void q.then(() => setTimeout(resolve, 50)).catch(reject);
       });
 
-      assert.strictEqual(
-        releaseStatusWhenEndEmitted,
-        true,
-        'client.release() should complete before end event is emitted on pool.query()',
-      );
+      expect(releaseStatusWhenEndEmitted).toBe(true);
     });
 
     it('should handle concurrent pool.end() calls gracefully and notify all callers', async () => {
@@ -924,8 +894,8 @@ describe('Pool Class', () => {
       // Call pool.end() concurrently 3 times
       await Promise.all([pool.end(), pool.end(), pool.end()]);
 
-      assert.strictEqual(pool.totalCount, 0);
-      assert.strictEqual(pool.idleCount, 0);
+      expect(pool.totalCount).toBe(0);
+      expect(pool.idleCount).toBe(0);
     });
 
     it('should drain active in-flight queries before pool.end() resolves', async () => {
@@ -944,15 +914,11 @@ describe('Pool Class', () => {
         void c1.release();
       }, 50);
 
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
       await pool.end();
 
-      assert.strictEqual(
-        queryFinished,
-        true,
-        'pool.end() must wait for active in-flight client to finish',
-      );
-      assert.strictEqual(pool.totalCount, 0);
+      expect(queryFinished).toBe(true);
+      expect(pool.totalCount).toBe(0);
     });
 
     it('should reject queued waitQueue acquirers when pool.end() is called', async () => {
@@ -973,7 +939,7 @@ describe('Pool Class', () => {
         waiterErrorMsg = err.message;
       });
 
-      assert.strictEqual(pool.waitingCount, 1);
+      expect(pool.waitingCount).toBe(1);
 
       // Release c1 after a short delay so pool.end() rejects waitQueue before c1 release
       setTimeout(() => {
@@ -983,12 +949,9 @@ describe('Pool Class', () => {
       await pool.end();
       await p2;
 
-      assert.strictEqual(waiterRejected, true);
-      assert.strictEqual(
-        waiterErrorMsg,
-        'Cannot acquire client from ending pool',
-      );
-      assert.strictEqual(pool.waitingCount, 0);
+      expect(waiterRejected).toBe(true);
+      expect(waiterErrorMsg).toBe('Cannot acquire client from ending pool');
+      expect(pool.waitingCount).toBe(0);
     });
 
     it('should remove idle client from pool when background error event occurs', async () => {
@@ -1004,28 +967,16 @@ describe('Pool Class', () => {
 
       const idleClient = await pool.connect();
       await idleClient.release();
-      assert.strictEqual(pool.idleCount, 1);
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.idleCount).toBe(1);
+      expect(pool.totalCount).toBe(1);
 
       // Emit a background connection error on the idle client handle
       idleClient.emit('error', new Error('Connection reset by peer'));
 
       // Broken client must be removed from the pool
-      assert.strictEqual(
-        pool.idleCount,
-        0,
-        'Broken idle client should be purged',
-      );
-      assert.strictEqual(
-        pool.totalCount,
-        0,
-        'Broken idle client should be removed from totalCount',
-      );
-      assert.strictEqual(
-        idleClient.isConnected,
-        false,
-        'Broken client should be closed',
-      );
+      expect(pool.idleCount).toBe(0);
+      expect(pool.totalCount).toBe(0);
+      expect(idleClient.isConnected).toBe(false);
 
       await pool.end();
     });
@@ -1052,12 +1003,11 @@ describe('Pool Class', () => {
 
         try {
           await connectPromise;
-          assert.fail(
+          throw new Error(
             'Should not allow client acquisition from an ending pool',
           );
         } catch (err: unknown) {
-          assert.strictEqual(
-            (err as Error).message,
+          expect((err as Error).message).toBe(
             'Cannot acquire client from ending pool',
           );
         }
@@ -1065,7 +1015,7 @@ describe('Pool Class', () => {
         Client.prototype.connect = originalConnect;
       }
 
-      assert.strictEqual(pool.totalCount, 0);
+      expect(pool.totalCount).toBe(0);
     });
 
     it('should forward streaming row and fields events from pool.query()', async () => {
@@ -1088,9 +1038,9 @@ describe('Pool Class', () => {
 
       await query;
 
-      assert.strictEqual(receivedFields.length, 1, 'Should emit fields event');
-      assert.strictEqual(receivedRows.length, 1, 'Should emit row event');
-      assert.ok(receivedResult, 'Should pass result object as 2nd parameter');
+      expect(receivedFields.length).toBe(1);
+      expect(receivedRows.length).toBe(1);
+      expect(receivedResult).toBeTruthy();
 
       await pool.end();
     });
@@ -1105,7 +1055,7 @@ describe('Pool Class', () => {
 
       // 1. Check out the only available connection slot
       const initialClient = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
 
       // 2. Queue Request A (index 0) and Request B (index 1) in FIFO order
       const resolutionOrder: string[] = [];
@@ -1117,11 +1067,7 @@ describe('Pool Class', () => {
         resolutionOrder.push('B');
         return client;
       });
-      assert.strictEqual(
-        pool.waitingCount,
-        2,
-        'Both requests should be queued',
-      );
+      expect(pool.waitingCount).toBe(2);
 
       // 3. initialClient encounters a fatal error and is destroyed.
       // Exactly ONE client slot is freed, so only Request A should be dequeued to get the replacement connection.
@@ -1147,22 +1093,14 @@ describe('Pool Class', () => {
       // Request B was queued before Request C, so Request B MUST be resolved before Request C.
       // Without the fix, re-entrant removeClient() prematurely pops Request B from waitQueue,
       // causing Request C to jump ahead of Request B in the queue (resulting in ['A', 'C']).
-      assert.deepStrictEqual(
-        resolutionOrder,
-        ['A', 'B'],
-        `FIFO queue order was violated. Expected Request B before Request C, but got: [${resolutionOrder.join(', ')}]`,
-      );
+      expect(resolutionOrder).toEqual(['A', 'B']);
 
       // 6. Request B completes and frees the connection for Request C
       const clientB = await requestB;
       await clientB.release();
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      assert.deepStrictEqual(
-        resolutionOrder,
-        ['A', 'B', 'C'],
-        'All requests should eventually resolve in strict FIFO order',
-      );
+      expect(resolutionOrder).toEqual(['A', 'B', 'C']);
 
       const clientC = await requestC;
       await clientC.release();
@@ -1177,11 +1115,15 @@ describe('Pool Class', () => {
       });
       void pool.end(); // Closing pool causes _doConnect to reject
       pool.connect((err, client, release) => {
-        assert.ok(err instanceof Error);
-        assert.strictEqual(client, undefined);
-        assert.strictEqual(typeof release, 'function');
-        assert.doesNotThrow(() => release!());
-        done();
+        try {
+          expect(err instanceof Error).toBeTruthy();
+          expect(client).toBe(undefined);
+          expect(typeof release).toBe('function');
+          expect(() => release!()).not.toThrow();
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -1192,7 +1134,7 @@ describe('Pool Class', () => {
         database: 'd',
       });
       const client = await pool.connect();
-      assert.strictEqual(pool.totalCount, 1);
+      expect(pool.totalCount).toBe(1);
 
       let removeEmitted = false;
       pool.on('remove', removedClient => {
@@ -1202,8 +1144,8 @@ describe('Pool Class', () => {
       });
 
       await client.end();
-      assert.strictEqual(removeEmitted, true);
-      assert.strictEqual(pool.totalCount, 0);
+      expect(removeEmitted).toBe(true);
+      expect(pool.totalCount).toBe(0);
       await pool.end();
     });
   });

--- a/handwritten/spanner-driver/test/unit/query_test.ts
+++ b/handwritten/spanner-driver/test/unit/query_test.ts
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {describe, it} from 'mocha';
 import {Query} from '../../src/lib/query.js';
 
 describe('Query Class', () => {
   it('should initialize Query with text string and positional values', () => {
     const q = new Query('SELECT $1', [42]);
-    assert.strictEqual(q.text, 'SELECT $1');
-    assert.deepStrictEqual(q.values, [42]);
+    expect(q.text).toBe('SELECT $1');
+    expect(q.values).toEqual([42]);
   });
 
   it('should initialize Query from QueryConfig object', () => {
@@ -29,74 +27,67 @@ describe('Query Class', () => {
       values: ['ACTIVE'],
       rowMode: 'array',
     });
-    assert.strictEqual(q.text, 'SELECT * FROM users WHERE status = $1');
-    assert.deepStrictEqual(q.values, ['ACTIVE']);
-    assert.strictEqual(q.rowMode, 'array');
+    expect(q.text).toBe('SELECT * FROM users WHERE status = $1');
+    expect(q.values).toEqual(['ACTIVE']);
+    expect(q.rowMode).toBe('array');
   });
 
   it('should handle null argument safely in Query constructor', () => {
     // @ts-expect-error Testing runtime null text argument
     const q = new Query(null);
-    assert.strictEqual(q.text, null);
-    assert.strictEqual(q.values, undefined);
+    expect(q.text).toBeNull();
+    expect(q.values).toBeUndefined();
   });
 
   it('should copy properties when constructed from existing Query instance', () => {
     const orig = new Query('SELECT 1', [10]);
     const q = new Query(orig);
-    assert.strictEqual(q.text, 'SELECT 1');
-    assert.deepStrictEqual(q.values, [10]);
+    expect(q.text).toBe('SELECT 1');
+    expect(q.values).toEqual([10]);
   });
 
   it('should allow overriding values and callback when constructed from existing Query instance', () => {
     const orig = new Query('SELECT $1');
     const cb = () => {};
     const q = new Query(orig, [99], cb);
-    assert.strictEqual(q.text, 'SELECT $1');
-    assert.deepStrictEqual(q.values, [99]);
-    assert.strictEqual(q.callback, cb);
+    expect(q.text).toBe('SELECT $1');
+    expect(q.values).toEqual([99]);
+    expect(q.callback).toBe(cb);
   });
 
   it('should handle callback argument overload correctly', () => {
     const callbackFn = () => {};
     const q = new Query('SELECT 1', callbackFn);
-    assert.strictEqual(q.text, 'SELECT 1');
-    assert.strictEqual(q.values, undefined);
-    assert.strictEqual(q.callback, callbackFn);
+    expect(q.text).toBe('SELECT 1');
+    expect(q.values).toBeUndefined();
+    expect(q.callback).toBe(callbackFn);
   });
 
   it('should resolve thenable promise on .then()', async () => {
     const q = new Query<{rowCount: number}>('SELECT 1');
     q.setPromise(Promise.resolve({rowCount: 1}));
     const res = await q;
-    assert.strictEqual(res.rowCount, 1);
+    expect(res.rowCount).toBe(1);
   });
 
   it('should clear promiseResolver after setPromise is called to prevent memory retention on multiple calls', async () => {
     const q = new Query<{rowCount: number}>('SELECT 1');
-    assert.notStrictEqual(
+    expect(
       (q as unknown as {promiseResolver: unknown}).promiseResolver,
-      undefined,
-    );
+    ).not.toBeUndefined();
     q.setPromise(Promise.resolve({rowCount: 1}));
-    assert.strictEqual(
+    expect(
       (q as unknown as {promiseResolver: unknown}).promiseResolver,
-      undefined,
-    );
+    ).toBeUndefined();
     q.setPromise(Promise.resolve({rowCount: 2}));
     const res = await q;
-    assert.strictEqual(res.rowCount, 2);
+    expect(res.rowCount).toBe(2);
   });
 
   it('should reject thenable promise on .catch()', async () => {
     const q = new Query('SELECT 1');
     q.setPromise(Promise.reject(new Error('Query failed')));
-    try {
-      await q;
-      assert.fail('Should have rejected');
-    } catch (err: unknown) {
-      assert.strictEqual((err as Error).message, 'Query failed');
-    }
+    await expect(q).rejects.toThrow('Query failed');
   });
 
   it('should invoke .finally() callback', async () => {
@@ -106,21 +97,21 @@ describe('Query Class', () => {
     await q.finally(() => {
       finallyInvoked = true;
     });
-    assert.strictEqual(finallyInvoked, true);
+    expect(finallyInvoked).toBe(true);
   });
 
   it('should not throw TypeError when calling catch() or then() on a newly constructed Query', () => {
     const q = new Query('SELECT 1');
-    assert.doesNotThrow(() => {
+    expect(() => {
       q.catch(() => {});
-    });
+    }).not.toThrow();
   });
 
   it('should resolve thenable promise via query.resolve()', async () => {
     const q = new Query<{rowCount: number}>('SELECT 1');
     q.resolve({rowCount: 5});
     const res = await q;
-    assert.strictEqual(res.rowCount, 5);
+    expect(res.rowCount).toBe(5);
   });
 
   it('should ignore duplicate query.resolve() calls and retain first resolved value', async () => {
@@ -128,18 +119,13 @@ describe('Query Class', () => {
     q.resolve({rowCount: 5});
     q.resolve({rowCount: 10});
     const res = await q;
-    assert.strictEqual(res.rowCount, 5);
+    expect(res.rowCount).toBe(5);
   });
 
   it('should ignore duplicate query.reject() calls and retain first rejection error', async () => {
     const q = new Query('SELECT 1');
     q.reject(new Error('First rejection'));
     q.reject(new Error('Second rejection'));
-    try {
-      await q;
-      assert.fail('Expected query promise to reject');
-    } catch (err: unknown) {
-      assert.strictEqual((err as Error).message, 'First rejection');
-    }
+    await expect(q).rejects.toThrow('First rejection');
   });
 });

--- a/handwritten/spanner-driver/test/unit/types_test.ts
+++ b/handwritten/spanner-driver/test/unit/types_test.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import {describe, it} from 'mocha';
 import {
   BuiltinOids,
   TypeOverrides,
@@ -31,134 +29,116 @@ import {Codec} from '../../src/lib/codec.js';
 describe('Type System & Parsers', () => {
   describe('Scalar Type Parsers', () => {
     it('should parse boolean values and string variants', () => {
-      assert.strictEqual(parseBool('true'), true);
-      assert.strictEqual(parseBool('t'), true);
-      assert.strictEqual(parseBool('1'), true);
-      assert.strictEqual(parseBool('yes'), true);
-      assert.strictEqual(parseBool('false'), false);
-      assert.strictEqual(parseBool('f'), false);
-      assert.strictEqual(parseBool('0'), false);
-      assert.strictEqual(parseBool('no'), false);
-      assert.strictEqual(parseBool(''), false);
+      expect(parseBool('true')).toBe(true);
+      expect(parseBool('t')).toBe(true);
+      expect(parseBool('1')).toBe(true);
+      expect(parseBool('yes')).toBe(true);
+      expect(parseBool('false')).toBe(false);
+      expect(parseBool('f')).toBe(false);
+      expect(parseBool('0')).toBe(false);
+      expect(parseBool('no')).toBe(false);
+      expect(parseBool('')).toBe(false);
 
-      assert.strictEqual(types.getTypeParser(BuiltinOids.BOOL)('t'), true);
-      assert.strictEqual(types.getTypeParser(BuiltinOids.BOOL)('f'), false);
+      expect(types.getTypeParser(BuiltinOids.BOOL)('t')).toBe(true);
+      expect(types.getTypeParser(BuiltinOids.BOOL)('f')).toBe(false);
     });
 
     it('should parse integers (INT8)', () => {
       // INT8 returns string by default to prevent 64-bit precision loss
       const largeInt = '9223372036854775807';
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.INT8)(largeInt),
-        largeInt,
-      );
+      expect(types.getTypeParser(BuiltinOids.INT8)(largeInt)).toBe(largeInt);
     });
 
     it('should parse floating point and decimal numbers (FLOAT4, FLOAT8, NUMERIC)', () => {
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.FLOAT8)('3.14159'),
-        3.14159,
-      );
-      assert.strictEqual(types.getTypeParser(BuiltinOids.FLOAT4)('2.5'), 2.5);
+      expect(types.getTypeParser(BuiltinOids.FLOAT8)('3.14159')).toBe(3.14159);
+      expect(types.getTypeParser(BuiltinOids.FLOAT4)('2.5')).toBe(2.5);
       // NUMERIC returns exact string by default
       const numStr = '12345678901234567890.123456789';
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.NUMERIC)(numStr),
-        numStr,
-      );
+      expect(types.getTypeParser(BuiltinOids.NUMERIC)(numStr)).toBe(numStr);
     });
 
     it('should parse text and string types (TEXT, VARCHAR, UUID)', () => {
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.TEXT)('hello world'),
+      expect(types.getTypeParser(BuiltinOids.TEXT)('hello world')).toBe(
         'hello world',
       );
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.VARCHAR)('varchar text'),
+      expect(types.getTypeParser(BuiltinOids.VARCHAR)('varchar text')).toBe(
         'varchar text',
       );
-      assert.strictEqual(
+      expect(
         types.getTypeParser(BuiltinOids.UUID)(
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
         ),
-        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-      );
+      ).toBe('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
     });
 
     it('should parse date and timestamp types (DATE, TIMESTAMP, TIMESTAMPTZ)', () => {
-      assert.strictEqual(
-        types.getTypeParser(BuiltinOids.DATE)('2026-08-07'),
+      expect(types.getTypeParser(BuiltinOids.DATE)('2026-08-07')).toBe(
         '2026-08-07',
       );
       const parsed = types.getTypeParser(BuiltinOids.TIMESTAMPTZ)(
         '2026-08-07 14:30:00.000000+00',
       ) as Date;
-      assert.ok(parsed instanceof Date);
-      assert.strictEqual(parsed.toISOString(), '2026-08-07T14:30:00.000Z');
+      expect(parsed).toBeInstanceOf(Date);
+      expect(parsed.toISOString()).toBe('2026-08-07T14:30:00.000Z');
     });
 
     it('should parse JSON and JSONB types into objects', () => {
       const parsed = types.getTypeParser(BuiltinOids.JSONB)(
         '{"key":"value","count":10}',
       );
-      assert.deepStrictEqual(parsed, {key: 'value', count: 10});
+      expect(parsed).toEqual({key: 'value', count: 10});
 
       const parsedArr = types.getTypeParser(BuiltinOids.JSON)(
         '[1, 2, "three"]',
       );
-      assert.deepStrictEqual(parsedArr, [1, 2, 'three']);
+      expect(parsedArr).toEqual([1, 2, 'three']);
     });
 
     it('should parse BYTEA into Node.js Buffer', () => {
       const base64Str = Buffer.from('hello spanner').toString('base64');
       const buf1 = types.getTypeParser(BuiltinOids.BYTEA)(base64Str) as Buffer;
-      assert.ok(Buffer.isBuffer(buf1));
-      assert.strictEqual(buf1.toString('utf8'), 'hello spanner');
+      expect(Buffer.isBuffer(buf1)).toBe(true);
+      expect(buf1.toString('utf8')).toBe('hello spanner');
 
       const hexStr = '\\x6465616462656566'; // 'deadbeef'
       const buf2 = types.getTypeParser(BuiltinOids.BYTEA)(hexStr) as Buffer;
-      assert.ok(Buffer.isBuffer(buf2));
-      assert.strictEqual(buf2.toString('hex'), '6465616462656566');
+      expect(Buffer.isBuffer(buf2)).toBe(true);
+      expect(buf2.toString('hex')).toBe('6465616462656566');
     });
   });
 
   describe('PostgreSQL Array Parser', () => {
     it('should parse 1D and nested pre-parsed array elements', () => {
-      assert.deepStrictEqual(
-        types.getTypeParser(1022)([1.5, 2.5, 3.5]),
-        [1.5, 2.5, 3.5],
-      );
-      assert.deepStrictEqual(types.getTypeParser(1016)(['10', '20']), [
-        '10',
-        '20',
+      expect(types.getTypeParser(1022)([1.5, 2.5, 3.5])).toEqual([
+        1.5, 2.5, 3.5,
       ]);
-      assert.deepStrictEqual(
-        types.getTypeParser(1000)([true, false, true, false]),
-        [true, false, true, false],
-      );
-      assert.deepStrictEqual(
+      expect(types.getTypeParser(1016)(['10', '20'])).toEqual(['10', '20']);
+      expect(types.getTypeParser(1000)([true, false, true, false])).toEqual([
+        true,
+        false,
+        true,
+        false,
+      ]);
+      expect(
         types.getTypeParser(1009)([
           ['a', 'b'],
           ['c', 'd'],
         ]),
-        [
-          ['a', 'b'],
-          ['c', 'd'],
-        ],
-      );
+      ).toEqual([
+        ['a', 'b'],
+        ['c', 'd'],
+      ]);
     });
 
     it('should parse arrays with NULL elements', () => {
-      assert.deepStrictEqual(
+      expect(
         parsePgArray([1, null, 3, null], val => (val ? Number(val) : null)),
-        [1, null, 3, null],
-      );
-      assert.deepStrictEqual(
+      ).toEqual([1, null, 3, null]);
+      expect(
         parsePgArray(['hello, world', 'foo, bar'], val => String(val)),
-        ['hello, world', 'foo, bar'],
-      );
-      assert.deepStrictEqual(parsePgArray([]), []);
-      assert.deepStrictEqual(parsePgArray(null), []);
+      ).toEqual(['hello, world', 'foo, bar']);
+      expect(parsePgArray([])).toEqual([]);
+      expect(parsePgArray(null)).toEqual([]);
     });
   });
 
@@ -166,17 +146,16 @@ describe('Type System & Parsers', () => {
     it('should allow custom parser registration and support format parameter overload', () => {
       const overrides = new TypeOverrides();
       overrides.setTypeParser(BuiltinOids.INT8, 'text', val => BigInt(val));
-      assert.strictEqual(
-        overrides.getTypeParser(BuiltinOids.INT8)('100'),
+      expect(overrides.getTypeParser(BuiltinOids.INT8)('100')).toBe(
         BigInt(100),
       );
 
-      assert.throws(() => {
+      expect(() => {
         overrides.setTypeParser(
           BuiltinOids.INT8,
           'not-a-function' as unknown as (val: unknown) => unknown,
         );
-      }, /Type parser must be a function/);
+      }).toThrow(/Type parser must be a function/);
     });
 
     it('should allow registering custom array parsers on array OIDs', () => {
@@ -184,7 +163,7 @@ describe('Type System & Parsers', () => {
       overrides.setTypeParser(1016, val =>
         overrides.arrayParser(val, x => Number(x) * 10),
       );
-      assert.deepStrictEqual(overrides.getTypeParser(1016)([1, 2]), [10, 20]);
+      expect(overrides.getTypeParser(1016)([1, 2])).toEqual([10, 20]);
     });
 
     it('should support hierarchical parent fallback in TypeOverrides', () => {
@@ -193,39 +172,32 @@ describe('Type System & Parsers', () => {
 
       const child = new TypeOverrides(parent);
       // Child inherits parent's INT8 parser
-      assert.strictEqual(
-        child.getTypeParser(BuiltinOids.INT8)('42'),
-        BigInt(42),
-      );
+      expect(child.getTypeParser(BuiltinOids.INT8)('42')).toBe(BigInt(42));
 
       // Child override takes precedence
       child.setTypeParser(BuiltinOids.INT8, val => Number(val));
-      assert.strictEqual(child.getTypeParser(BuiltinOids.INT8)('42'), 42);
+      expect(child.getTypeParser(BuiltinOids.INT8)('42')).toBe(42);
       // Parent remains unchanged
-      assert.strictEqual(
-        parent.getTypeParser(BuiltinOids.INT8)('42'),
-        BigInt(42),
-      );
+      expect(parent.getTypeParser(BuiltinOids.INT8)('42')).toBe(BigInt(42));
     });
 
     it('should provide arrayParser helper and throw on non-numeric OID', () => {
       const overrides = new TypeOverrides();
-      assert.deepStrictEqual(
-        overrides.arrayParser([10, 20], val => Number(val) + 1),
-        [11, 21],
-      );
+      expect(overrides.arrayParser([10, 20], val => Number(val) + 1)).toEqual([
+        11, 21,
+      ]);
 
-      assert.throws(() => {
+      expect(() => {
         overrides.getTypeParser('INVALID_OID');
-      }, /Invalid PostgreSQL OID/);
+      }).toThrow(/Invalid PostgreSQL OID/);
 
-      assert.throws(() => {
+      expect(() => {
         overrides.getTypeParser(BuiltinOids.INT8, 'binary');
-      }, /Binary wire format is not supported/);
+      }).toThrow(/Binary wire format is not supported/);
 
-      assert.throws(() => {
+      expect(() => {
         overrides.setTypeParser(BuiltinOids.INT8, 'binary', val => val);
-      }, /Binary wire format is not supported/);
+      }).toThrow(/Binary wire format is not supported/);
     });
   });
 
@@ -246,7 +218,7 @@ describe('Type System & Parsers', () => {
         parsers,
         'object',
       );
-      assert.deepStrictEqual(decoded, {
+      expect(decoded).toEqual({
         id: 101,
         name: 'Spanner',
         active: true,
@@ -262,7 +234,7 @@ describe('Type System & Parsers', () => {
         parsers,
         'array',
       );
-      assert.deepStrictEqual(decoded, [101, 'Spanner', true, ['cloud', 'db']]);
+      expect(decoded).toEqual([101, 'Spanner', true, ['cloud', 'db']]);
     });
 
     it('should decode rows with custom TypeOverrides and fallback', () => {
@@ -275,20 +247,14 @@ describe('Type System & Parsers', () => {
         fields,
         parsers,
       );
-      assert.strictEqual(decoded.id, 'id_101');
-      assert.strictEqual(decoded.name, 'Spanner');
+      expect(decoded.id).toBe('id_101');
+      expect(decoded.name).toBe('Spanner');
     });
 
     it('should return default PG type overrides via getDefaultTypeOverrides', () => {
       const defaultTypes = getDefaultTypeOverrides('pg');
-      assert.strictEqual(
-        defaultTypes.getTypeParser(BuiltinOids.BOOL)('t'),
-        true,
-      );
-      assert.strictEqual(
-        defaultTypes.getTypeParser(BuiltinOids.FLOAT8)('42'),
-        42,
-      );
+      expect(defaultTypes.getTypeParser(BuiltinOids.BOOL)('t')).toBe(true);
+      expect(defaultTypes.getTypeParser(BuiltinOids.FLOAT8)('42')).toBe(42);
     });
 
     it('should decode rows containing structValue and array of structValues', () => {
@@ -331,7 +297,7 @@ describe('Type System & Parsers', () => {
         structFields,
         parsers,
       );
-      assert.deepStrictEqual(decoded, {
+      expect(decoded).toEqual({
         user: {id: '100', score: 98.5},
         items: [{itemId: 'item_1', qty: 5}],
       });
@@ -339,11 +305,11 @@ describe('Type System & Parsers', () => {
 
     it('should handle pre-parsed values gracefully in parsers', () => {
       const date = new Date('2026-08-11T10:00:00.000Z');
-      assert.strictEqual(parseTimestamp(date), date);
-      assert.strictEqual(parseBool(true), true);
-      assert.strictEqual(parseFloatVal(3.14), 3.14);
-      assert.strictEqual(parseString(100), '100');
-      assert.strictEqual(parseBytea(Buffer.from('hi')).toString(), 'hi');
+      expect(parseTimestamp(date)).toBe(date);
+      expect(parseBool(true)).toBe(true);
+      expect(parseFloatVal(3.14)).toBe(3.14);
+      expect(parseString(100)).toBe('100');
+      expect(parseBytea(Buffer.from('hi')).toString()).toBe('hi');
     });
   });
 });

--- a/retro-17.md
+++ b/retro-17.md
@@ -1,0 +1,88 @@
+# Retro: Issue #17 - Migrate `@google-cloud/spanner-driver` to Jest
+
+## 1. Executive Summary
+Issue #17 requested migrating the `@google-cloud/spanner-driver` package from the legacy Mocha, Sinon, and c8 test ecosystem to Jest, following the blueprint established in pull request [#9218](https://github.com/googleapis/google-cloud-node/pull/9218) (migrating `@google-cloud/paginator` to Jest).
+
+All 8 unit test suites (138 test cases) and the system test suite have been fully migrated to Jest and `ts-jest`. Full build compilation (`npm run compile`), linting (`npm run lint`), code coverage collection (`npm test`), and system test execution (`npm run system-test`) have been verified and pass cleanly.
+
+---
+
+## 2. Changes Made
+
+### A. Infrastructure & Dependency Swap
+* **Removed Legacy Test Dependencies**:
+  * `mocha` (`^11.1.0`)
+  * `@types/mocha` (`^10.0.10`)
+  * `sinon` (`^21.0.3`)
+  * `@types/sinon` (`^17.0.4`)
+  * `c8` (`^10.1.3`)
+* **Installed Jest Dependencies**:
+  * `jest` (`^29.7.0`)
+  * `ts-jest` (`^29.4.12`)
+  * `@types/jest` (`^29.5.14`)
+
+### B. Configuration Files
+* **Created `jest.config.js`**:
+  * Configured `ts-jest` modern transform with `tsconfig.json`.
+  * Added `moduleNameMapper` (`'^(\\.{1,2}/.*)\\.js$': '$1'`) to resolve TypeScript ESM relative imports containing `.js` extensions directly to their TypeScript source files.
+  * Configured `testMatch` (`['<rootDir>/test/**/*_test.ts', '<rootDir>/system-test/**/*.ts']`) and enabled `clearMocks: true`.
+  * Included the standard Google Apache 2.0 license header.
+* **Cleaned Up Legacy Configs**:
+  * Removed `.mocharc.cjs`.
+  * Removed `.c8rc.json`.
+  * Fixed `handwritten/spanner-driver/.eslintrc.json` extends path to point to `./node_modules/gts`.
+
+### C. Package Scripts Alignment (`package.json`)
+* Replaced `"test:esm"`, `"test:cjs"`, and composite `"test"` commands with `"test": "jest test/unit --coverage"`.
+* Updated `"system-test"` to `"jest system-test"`.
+* Retained `"test:pg-suite": "node test/pg-suite/run_pg_suite.cjs"` for standalone PostgreSQL test runner.
+
+### D. Interoperability & Source Updates
+* Updated protobuf import in `src/lib/pg/types.ts`, `src/lib/codec.ts`, `test/unit/mock_native.ts`, and `test/unit/codec_test.ts` from `import pkg from '@google-cloud/spanner-api/build/protos/protos.js'` to `import * as pkg from '@google-cloud/spanner-api/build/protos/protos.js'` with robust fallback resolution (`pkg.google || pkg.default?.google || pkg.default`) ensuring seamless runtime execution across both ESM and CommonJS/ts-jest execution environments.
+
+### E. Test Suite Migration
+Migrated all test files to native Jest matchers and lifecycle hooks:
+* `test/unit/pg_utilities_test.ts`
+* `test/unit/errors_test.ts`
+* `test/unit/config_test.ts`
+* `test/unit/query_test.ts`
+* `test/unit/codec_test.ts`
+* `test/unit/types_test.ts`
+* `test/unit/client_test.ts`
+* `test/unit/pool_test.ts`
+* `test/unit/mock_native.ts`
+* `system-test/driver.ts`
+
+Key test transformations included:
+* Replacing `assert.strictEqual(a, b)` with `expect(a).toBe(b)`.
+* Replacing `assert.deepStrictEqual(a, b)` with `expect(a).toEqual(b)`.
+* Replacing `assert.ok(a)` with `expect(a).toBeTruthy()` / `expect(a).toBeDefined()`.
+* Replacing `assert.match(str, regex)` with `expect(str).toMatch(regex)`.
+* Replacing `assert.throws(fn)` with `expect(fn).toThrow()`.
+* Replacing `sinon.stub(obj, 'meth').callsFake(...)` with `jest.spyOn(obj, 'meth').mockImplementation(...)`.
+* Converting Mocha hooks (`before`, `after`, `this.timeout`) in `system-test/driver.ts` to Jest (`beforeAll`, `afterAll`, `jest.setTimeout`).
+* Wrapping asynchronous `done()` callback assertions in `try / catch` blocks with error routing to `done(e)` to prevent hanging test suites.
+
+---
+
+## 3. Verification & Results
+
+1. **TypeScript Build (`npm run compile`)**:
+   * ESM (`tsc -p .`) and CommonJS (`tsc -p ./tsconfig.cjs.json`) compiled successfully without any diagnostics or errors.
+2. **Linting (`npm run lint`)**:
+   * `gts check` passed with zero errors and zero warnings.
+3. **Unit Tests & Coverage (`npm test`)**:
+   * **Test Suites**: 8 passed, 8 total
+   * **Tests**: 138 passed, 138 total
+   * **Statements**: 90.72%
+   * **Branches**: 76.43%
+   * **Functions**: 84.24%
+   * **Lines**: 92.69%
+4. **System Tests (`npm run system-test`)**:
+   * Executed and cleanly skipped without failure in the absence of live GCP credentials.
+
+---
+
+## 4. Key Learnings & Takeaways
+* **NodeNext ESM / Jest Module Mapping**: Projects configured with `"module": "nodenext"` use `.js` extension specifiers in TypeScript imports. `jest.config.js` requires `moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' }` so that `ts-jest` resolves these paths directly to `.ts` source files without requiring pre-compilation.
+* **CJS Protobuf Interoperability**: Protobuf bundles compiled to CommonJS lack default exports; using namespace imports (`import * as pkg`) with fallback object extraction provides unified compatibility between native ESM execution and ts-jest execution.


### PR DESCRIPTION
Automated resolution and investigation for issue #17.

- **Branch**: `issue-17-fix`
- **Post-mortem**: see `retro-17.md` in the branch.

Fixes: https://github.com/danieljbruce/google-cloud-node/issues/17